### PR TITLE
Fix a validation example

### DIFF
--- a/Section 5 -- Validation.md
+++ b/Section 5 -- Validation.md
@@ -31,7 +31,7 @@ type Dog : Pet {
 }
 
 interface Sentient { name: String! }
-interface Pet { name: String!, nickname: String }
+interface Pet { name: String! }
 
 type Alien : Sentient { name: String!, homePlanet: String }
 type Human : Sentient { name: String! }
@@ -101,7 +101,7 @@ implementors of the union define the fieldName.
 
 For example the following is invalid
 
-```graphql
+```!graphql
 fragment directFieldSelectionOnUnion on CatOrDog {
   directField
 }


### PR DESCRIPTION
I think this example is valid because `nickname` is defined in `Pet` interface too. So I changed it to `barkVolume` which is the field of a concrete implementor `Dog`.