### PR TITLE
move the TOC to the side for easier navigation

### DIFF
--- a/spec.css
+++ b/spec.css
@@ -1,7 +1,7 @@
 body {
   color: #333333;
   font: 13pt/18pt Cambria, "Palatino Linotype", Palatino, "Liberation Serif", serif;
-  margin-left: 300px ;
+  margin-left: 350px ;
   max-width: 780px;
 }
 
@@ -72,7 +72,6 @@ footer {
 /* Table of contents */
 
 .spec-toc {
-  margin: 1em 0 3em;
   position: fixed;
   top: 0;
   left: 0;

--- a/spec.css
+++ b/spec.css
@@ -1,7 +1,7 @@
 body {
   color: #333333;
   font: 13pt/18pt Cambria, "Palatino Linotype", Palatino, "Liberation Serif", serif;
-  margin: 6rem auto 12rem;
+  margin-left: 300px ;
   max-width: 780px;
 }
 
@@ -73,6 +73,13 @@ footer {
 
 .spec-toc {
   margin: 1em 0 3em;
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 250px;
+  height: 100vh;
+  margin-left: 10px;
+  overflow-y: auto;
 }
 
 .spec-toc::before {


### PR DESCRIPTION
For those of us that are implementing the spec, its kinda hard to go [up and down the page](http://tholman.com/elevator.js/) for the TOC this would make things simpler. [preview](https://sevki.github.io/graphql-spec/)

![spec_css_-__users_sevki_code_go_src_sevki_org_graphql_graphql_-_atom](https://cloud.githubusercontent.com/assets/429977/8633233/e7f37480-27c6-11e5-86a7-9c7869340d2a.png)