### PR TITLE
Clarify Number parsing, expand exponent grammar

### DIFF
--- a/Section 2 -- Language.md
+++ b/Section 2 -- Language.md
@@ -222,12 +222,12 @@ contain variables.
 
 **Int**
 
-Int is a number specified without a decimal point (ex. `1`).
+Int is a number specified without a decimal point or exponent (ex. `1`).
 
 **Float**
 
-A Float numbers always includes a decimal point (ex. `1.0`) and may optionally
-also include an exponent (ex. `6.0221413e23`).
+A Float number includes either a decimal point (ex. `1.0`) or an exponent
+(ex. `1e50`) or both (ex. `6.0221413e23`).
 
 **Boolean**
 

--- a/Section 8 -- Grammar.md
+++ b/Section 8 -- Grammar.md
@@ -158,24 +158,30 @@ Punctuator : one of ! $ ( ) ... : = @ [ ] { | }
 
 Name : /[_A-Za-z][_0-9A-Za-z]*/
 
-IntValue : Sign? IntegerPart
+IntValue : IntegerPart
 
-FloatValue : Sign? IntegerPart . Digit+ ExponentPart?
-
-Sign : -
+FloatValue :
+  - IntegerPart FractionalPart
+  - IntegerPart ExponentPart
+  - IntegerPart FractionalPart ExponentPart
 
 IntegerPart :
-  - 0
-  - NonZeroDigit
-  - NonZeroDigit Digit+
+  - NegativeSign? 0
+  - NegativeSign? NonZeroDigit Digit+?
 
-ExponentPart : e Sign? Digit+
+FractionalPart : . Digit+
 
-NonZeroDigit : one of 1 2 3 4 5 6 7 8 9
+ExponentPart : ExponentIndicator Sign? Digit+
 
-Digit :
-  - 0
-  - NonZeroDigit
+Digit : one of 0 1 2 3 4 5 6 7 8 9
+
+NonZeroDigit : Digit but not `0`
+
+Sign : one of + -
+
+NegativeSign : -
+
+ExponentIndicator : one of `e` `E`
 
 StringValue :
   - `""`


### PR DESCRIPTION
This makes Number parsing match the JSON spec for numbers, reducing the chances for naive error.

It also hopefully clarifies the non-zero leading case for numbers in `IntegerPart`.