### PR TITLE
make __type name arg a non-null

### DIFF
--- a/Section 4 -- Introspection.md
+++ b/Section 4 -- Introspection.md
@@ -104,7 +104,7 @@ operation.
 
 ```
 __schema : __Schema!
-__type(name: String) : __Type
+__type(name: String!) : __Type
 ```
 
 These fields are implicit and do not appear in the fields list in the root type


### PR DESCRIPTION
According to the JS implementation, this is a `NonNull` argument (which makes more sense).