### PR TITLE
Capitalize Unicode character in Appendix A

### DIFF
--- a/spec/Appendix A -- Notation Conventions.md
+++ b/spec/Appendix A -- Notation Conventions.md
@@ -22,7 +22,7 @@ of the sequences it is defined by, until all non-terminal symbols have been
 replaced by terminal characters.
 
 Terminals are represented in this document in a monospace font in two forms: a
-specific unicode character or sequence of unicode characters (ex. {`=`} or {`terminal`}), and a pattern of unicode characters defined by a regular expression
+specific Unicode character or sequence of Unicode characters (ex. {`=`} or {`terminal`}), and a pattern of Unicode characters defined by a regular expression
 (ex {/[0-9]+/}).
 
 Non-terminal production rules are represented in this document using the
@@ -48,12 +48,12 @@ ListOfLetterA :
 
 The GraphQL language is defined in a syntactic grammar where terminal symbols
 are tokens. Tokens are defined in a lexical grammar which matches patterns of
-source characters. The result of parsing a sequence of source unicode characters
+source characters. The result of parsing a sequence of source Unicode characters
 produces a GraphQL AST.
 
 A Lexical grammar production describes non-terminal "tokens" by
-patterns of terminal unicode characters. No "whitespace" or other ignored
-characters may appear between any terminal unicode characters in the lexical
+patterns of terminal Unicode characters. No "whitespace" or other ignored
+characters may appear between any terminal Unicode characters in the lexical
 grammar production. A lexical grammar production is distinguished by a two colon
 `::` definition.
 
@@ -166,13 +166,13 @@ Example_param :
 This specification describes the semantic value of many grammar productions in
 the form of a list of algorithmic steps.
 
-For example, this describes how a parser should interpret a unicode escape
+For example, this describes how a parser should interpret a Unicode escape
 sequence which appears in a string literal:
 
 EscapedUnicode :: u /[0-9A-Fa-f]{4}/
 
   * Let {codePoint} be the number represented by the four-digit hexidecimal sequence.
-  * The string value is the unicode character represented by {codePoint}.
+  * The string value is the Unicode character represented by {codePoint}.
 
 
 ## Algorithms


### PR DESCRIPTION
Unicode character collocation should be capitalised. Examples:
https://tools.ietf.org/html/rfc5198
https://tools.ietf.org/html/rfc3629
https://en.wikipedia.org/wiki/Unicode
