### PR TITLE
[RFC] Null value

### DIFF
--- a/spec/Appendix B -- Grammar Summary.md
+++ b/spec/Appendix B -- Grammar Summary.md
@@ -127,11 +127,14 @@ Value[Const] :
   - FloatValue
   - StringValue
   - BooleanValue
+  - NullValue
   - EnumValue
   - ListValue[?Const]
   - ObjectValue[?Const]
 
 BooleanValue : one of `true` `false`
+
+NullValue : `null`
 
 EnumValue : Name but not `true`, `false` or `null`
 

--- a/spec/Section 2 -- Language.md
+++ b/spec/Section 2 -- Language.md
@@ -634,6 +634,7 @@ Value[Const] :
   - FloatValue
   - StringValue
   - BooleanValue
+  - NullValue
   - EnumValue
   - ListValue[?Const]
   - ObjectValue[?Const]
@@ -736,6 +737,37 @@ StringCharacter :: \ EscapedCharacter
   * Return the character value of {EscapedCharacter}.
 
 
+### Null Value
+
+NullValue : `null`
+
+Null values are represented as the keyword {null}.
+
+GraphQL has two semantically different ways to represent the lack of a value:
+
+  * Explicitly providing the literal value: {null}.
+  * Implicitly not providing a value at all.
+
+For example, these two field calls are similar, but are not identical:
+
+```graphql
+{
+  field(arg: null)
+  field
+}
+```
+
+The first has explictly provided {null} to the argument "arg", while the second
+has implicitly not provided a value to the argument "arg". These two forms may
+be interpreted differently. For example, a mutation representing deleting a
+field vs not altering a field, respectively. Niether form may be used for an
+input expecting a Non-Null type.
+
+Note: The same two methods of representing the lack of a value are possible via
+variables by either providing the a variable value as {null} and not providing
+a variable value at all.
+
+
 ### Enum Value
 
 EnumValue : Name but not `true`, `false` or `null`
@@ -744,9 +776,6 @@ Enum values are represented as unquoted names (ex. `MOBILE_WEB`). It is
 recommended that Enum values be "all caps". Enum values are only used in
 contexts where the precise enumeration type is known. Therefore it's not
 necessary to supply an enumeration type name in the literal.
-
-An enum value cannot be "null" in order to avoid confusion. GraphQL
-does not supply a value literal to represent the concept {null}.
 
 
 ### List Value

--- a/spec/Section 5 -- Validation.md
+++ b/spec/Section 5 -- Validation.md
@@ -629,22 +629,26 @@ fragment stringIntoInt on Arguments {
 ```
 
 
-#### Required Arguments
+#### Required Non-Null Arguments
 
   * For each Field or Directive in the document.
   * Let {arguments} be the arguments provided by the Field or Directive.
   * Let {argumentDefinitions} be the set of argument definitions of that Field or Directive.
-  * For each {definition} in {argumentDefinitions}
-    * Let {type} be the expected type of {definition}
-    * If {type} is Non-Null
-      * Let {argumentName} be the name of {definition}
+  * For each {definition} in {argumentDefinitions}:
+    * Let {type} be the expected type of {definition}.
+    * If {type} is Non-Null:
+      * Let {argumentName} be the name of {definition}.
       * Let {argument} be the argument in {arguments} named {argumentName}
       * {argument} must exist.
+      * Let {value} be the value of {argument}.
+      * {value} must not be the {null} literal.
 
 ** Explanatory Text **
 
 Arguments can be required. Arguments are required if the type of the argument
-is non-null. If it is not non-null, the argument is optional.
+is non-null. If it is not non-null, the argument is optional. When an argument
+type is non-null, and is required, the explicit value {null} may also not
+be provided.
 
 For example the following are valid:
 
@@ -676,6 +680,13 @@ fragment missingRequiredArg on Arguments {
 }
 ```
 
+Providing the explicit value {null} is also not valid.
+
+```!graphql
+fragment missingRequiredArg on Arguments {
+  notNullBooleanArgField(nonNullBooleanArg: null)
+}
+```
 
 ## Fragments
 

--- a/spec/Section 6 -- Execution.md
+++ b/spec/Section 6 -- Execution.md
@@ -535,7 +535,7 @@ the field returned {null}, and an error must be added to the {"errors"} list
 in the response.
 
 If the result of resolving a field is {null} (either because the function to
-resolve the field returned `null` or because an error occurred), and that
+resolve the field returned {null} or because an error occurred), and that
 field is of a `Non-Null` type, then a field error is thrown. The
 error must be added to the {"errors"} list in the response.
 


### PR DESCRIPTION
This proposal adds a null literal to the GraphQL language and allows it to be provided to nullable typed arguments and input object fields.

This presents an opportunity for a GraphQL service to interpret the explicitly provided null differently from the implicitly not-provided value, which may be especially useful when performing mutations using a per-field set API.

For example, this query may represent the removal/clearing of the "bar" field from thing with id: 4.

```
mutation editThing {
  editThing(id: 4, edits: { foo: "added", bar: null }) {
    # ...
  }
}
```

In addition to allowing `null` as a literal value, this also proposes interpretting the variables JSON to distinguish between explicit null and implicit not provided:

```
mutation editThing($edits: EditObj) {
  editThing(id: 4, edits: $edits) {
    # ...
  }
}
```

This variables results in the unsetting of `bar`

```
{ "edits": { "foo": "added", "bar": null } }
```

Finally, this proposes following the not-provided-ness of variables to their positions in arguments and input-obj fields

```
mutation editThing($editBaz: String) {
  editThing(id: 4, edits: { foo: "added", bar: null, baz: $editBaz }) {
    # ...
  }
}
```

Such that the three variables are semantically different:

 * `{}` The "baz" input field is "not provided"
 * `{"editBaz": null}` The "baz" input field is `null`
 * `{"editBaz": "added"}` The "baz" input field is `"added"`