### PR TITLE
Update the type syntax in examples to match the IDL

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ interface Character {
   appearsIn: [Episode]
 }
 
-type Human : Character {
+type Human implements Character {
   id: String
   name: String
   friends: [Character]
@@ -161,7 +161,7 @@ type Human : Character {
   homePlanet: String
 }
 
-type Droid : Character {
+type Droid implements Character {
   id: String
   name: String
   friends: [Character]
@@ -197,7 +197,7 @@ interface Character {
   appearsIn: [Episode]
 }
 
-type Human : Character {
+type Human implements Character {
   id: String!
   name: String
   friends: [Character]
@@ -205,7 +205,7 @@ type Human : Character {
   homePlanet: String
 }
 
-type Droid : Character {
+type Droid implements Character {
   id: String!
   name: String
   friends: [Character]

--- a/spec/Section 3 -- Type System.md
+++ b/spec/Section 3 -- Type System.md
@@ -434,12 +434,12 @@ interface NamedEntity {
   name: String
 }
 
-type Person : NamedEntity {
+type Person implements NamedEntity {
   name: String
   age: Int
 }
 
-type Business : NamedEntity {
+type Business implements NamedEntity {
   name: String
   employeeCount: Int
 }

--- a/spec/Section 5 -- Validation.md
+++ b/spec/Section 5 -- Validation.md
@@ -21,7 +21,7 @@ in order to demonstrate examples:
 ```
 enum DogCommand { SIT, DOWN, HEEL }
 
-type Dog : Pet {
+type Dog implements Pet {
   name: String!
   nickname: String
   barkVolume: Int
@@ -37,16 +37,16 @@ interface Pet {
   name: String!
 }
 
-type Alien : Sentient {
+type Alien implements Sentient {
   name: String!
   homePlanet: String
 }
 
-type Human : Sentient {
+type Human implements Sentient {
   name: String!
 }
 
-type Cat : Pet {
+type Cat implements Pet {
   name: String!
   nickname: String
   meowVolume: Int


### PR DESCRIPTION
Use `ImplementsInterfaces` syntax from GraphQL IDL in the examples.