### PR TITLE
[RFC] Move input field uniqueness validator

### DIFF
--- a/spec/Section 2 -- Language.md
+++ b/spec/Section 2 -- Language.md
@@ -712,7 +712,6 @@ ObjectValue : { ObjectField+ }
   * Let {inputObject} be a new input object value with no fields.
   * For each {field} in {ObjectField+}
     * Let {name} be {Name} in {field}.
-    * If {inputObject} contains a field named {name} throw Syntax Error.
     * Let {value} be the result of evaluating {Value} in {field}.
     * Add a field to {inputObject} of name {name} containing value {value}.
   * Return {inputObject}

--- a/spec/Section 5 -- Validation.md
+++ b/spec/Section 5 -- Validation.md
@@ -1028,6 +1028,31 @@ fragment sentientFragment on Sentient {
 is not valid because there exists no type that implements both {Pet}
 and {Sentient}.
 
+## Values
+
+### Input Object Field Uniqueness
+
+** Formal Specification **
+
+  * For each input object value {inputObject} in the document.
+  * For every {inputField} in {inputObject}
+    * Let {name} be the Name of {inputField}.
+    * Let {fields} be all Input Object Fields named {name} in {inputObject}.
+    * {fields} must be the set containing only {inputField}.
+
+** Explanatory Text **
+
+Input objects must not contain more than one fields of the same name, otherwise
+an amgibuity would exist which includes an ignored portion of syntax.
+
+For example the following query will not pass validation.
+
+```graphql
+{
+  field(arg: { field: true, field: false })
+}
+```
+
 ## Directives
 
 ### Directives Are Defined


### PR DESCRIPTION
This proposes moving input field uniqueness assertion from the parser to the validator. This simplifies the parser and allows these errors to be reported as part of the collection of validation errors which is actually more valuable.

This removes the only example of a non-grammar syntax error from the language, which simplifies implementations.