### PR TITLE
[RFC] Clarify and restrict unicode support

### DIFF
--- a/spec/Appendix A -- Notation Conventions.md
+++ b/spec/Appendix A -- Notation Conventions.md
@@ -166,13 +166,16 @@ Example_param :
 This specification describes the semantic value of many grammar productions in
 the form of a list of algorithmic steps.
 
-For example, this describes how a parser should interpret a Unicode escape
-sequence which appears in a string literal:
+For example, this describes how a parser should interpret a string literal:
 
-EscapedUnicode :: u /[0-9A-Fa-f]{4}/
+StringValue :: `""`
 
-  * Let {codePoint} be the number represented by the four-digit hexadecimal sequence.
-  * The string value is the Unicode character represented by {codePoint}.
+  * Return an empty Unicode character sequence.
+
+StringValue :: `"` StringCharacter+ `"`
+
+  * Return the Unicode character sequence of all {StringCharacter}
+    Unicode character values.
 
 
 ## Algorithms

--- a/spec/Appendix B -- Grammar Summary.md
+++ b/spec/Appendix B -- Grammar Summary.md
@@ -1,31 +1,29 @@
 # B. Appendix: Grammar Summary
 
-SourceCharacter :: "Any Unicode code point"
+SourceCharacter :: /[\u0009\u000A\u000D\u0020-\uFFFF]/
 
 
 ## Ignored Tokens
 
 Ignored ::
+  - UnicodeBOM
   - WhiteSpace
   - LineTerminator
   - Comment
   - Comma
 
+UnicodeBOM :: "Byte Order Mark (U+FEFF)"
+
 WhiteSpace ::
   - "Horizontal Tab (U+0009)"
-  - "Vertical Tab (U+000B)"
-  - "Form Feed (U+000C)"
   - "Space (U+0020)"
-  - "No-break Space (U+00A0)"
 
 LineTerminator ::
   - "New Line (U+000A)"
-  - "Carriage Return (U+000D)"
-  - "Line Separator (U+2028)"
-  - "Paragraph Separator (U+2029)"
+  - "Carriage Return (U+000D)" [ lookahead ! "New Line (U+000A)" ]
+  - "Carriage Return (U+000D)" "New Line (U+000A)"
 
-Comment ::
-  - `#` CommentChar*
+Comment :: `#` CommentChar*
 
 CommentChar :: SourceCharacter but not LineTerminator
 
@@ -76,10 +74,10 @@ StringValue ::
 
 StringCharacter ::
   - SourceCharacter but not `"` or \ or LineTerminator
-  - \ EscapedUnicode
+  - \u EscapedUnicode
   - \ EscapedCharacter
 
-EscapedUnicode :: u /[0-9A-Fa-f]{4}/
+EscapedUnicode :: /[0-9A-Fa-f]{4}/
 
 EscapedCharacter :: one of `"` \ `/` b f n r t
 


### PR DESCRIPTION
This proposal alters the parser grammar to be more specific about what unicode characters are allowed as source, restricts those characters interpretted as white space or line breaks, and clarifies line break behavior relative to error reporting with a non-normative note.