### PR TITLE
Fix invalid fragment syntax in one of the examples.

### DIFF
--- a/spec/Section 5 -- Validation.md
+++ b/spec/Section 5 -- Validation.md
@@ -349,7 +349,7 @@ are the leaf nodes of any GraphQL query.
 The following is valid.
 
 ```graphql
-fragment scalarSelection: Dog {
+fragment scalarSelection on Dog {
   barkVolume
 }
 ```
@@ -357,7 +357,7 @@ fragment scalarSelection: Dog {
 The following is invalid.
 
 ```!graphql
-fragment scalarSelectionsNotAllowedOnBoolean : Dog {
+fragment scalarSelectionsNotAllowedOnBoolean on Dog {
   barkVolume {
     sinceWhen
   }


### PR DESCRIPTION
Updated a couple of examples to use the correct fragment definition, which uses ` on ` instead of `:` between the fragment name and the type name.