### PR TITLE
Mention that variable values need to be coerced for execution.

### DIFF
--- a/spec/Section 3 -- Type System.md
+++ b/spec/Section 3 -- Type System.md
@@ -735,11 +735,11 @@ query withNullableVariable($var: String) {
 Hence, if the value for a Non Null type is hard-coded in the query, it is always
 coerced using the input coercion for the wrapped type.
 
-When a Non Null input has its value set using a variable, the coerced value
-should be `null` if the provided value is `null`-like in the provided
-representation, or if the provided value is omitted. Otherwise, the coerced
-value is the result of running the wrapped type's input coercion on the
-provided value.
+When a Non Null input has its value set using a variable, a query
+error must be raised if the provided value is `null`-like in the
+provided representation, or if the provided value is omitted.
+Otherwise, the coerced value is the result of running the wrapped
+type's input coercion on the provided value.
 
 ## Directives
 

--- a/spec/Section 6 -- Execution.md
+++ b/spec/Section 6 -- Execution.md
@@ -14,6 +14,14 @@ error. If the operation is found, then the result of evaluating the request
 should be the result of evaluating the operation according to the “Evaluating
 operations” section.
 
+## Coercing Variables
+
+If the operation has defined any variables, then the values for
+those variables need to be coerced using the input coercion rules
+of variable's declared type. If a query error is encountered during
+input coercion of variable values, then the operation fails without
+execution.
+
 ## Evaluating operations
 
 The type system, as described in the “Type System” part of the spec, must


### PR DESCRIPTION
Variable value coercion is implied during input coercion for the types, but there isn't a mention of when it should be done.  I believe this underspecification can lead to implementations missing input coercion on variables, using the raw unvalidated variable values instead, as was the case with graphql-ruby until I recently reported the issue https://github.com/rmosolgo/graphql-ruby/issues/46.

The semantics of whether input coercion errors should result in the operation to fail or if the field resolution that uses the variable should fail was unclear.  [graphql-js coerces variables when building the execution context](https://github.com/graphql/graphql-js/blob/v0.4.7/src/execution/execute.js#L198), so it looks like query errors would result in the operation to fail, thus I documented this behaviour in the specification.

The input coercion also implied that `null` variable values would be accepted for Non-Null types without raising an error, which doesn't make sense for variables which don't have their values validated like literals, so I changed the sentence to say that a query error should be raised.  [graphql-js raises an error in this case.](https://github.com/graphql/graphql-js/blob/v0.4.7/src/execution/values.js#L107-L111)