### PR TITLE
Add table of contents for easier navigation

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,16 @@ data models.
 
 [![Public Slack Discussion](https://graphql-slack.herokuapp.com/badge.svg)](https://graphql-slack.herokuapp.com/)
 
+## Table of Contents
+
+  1. [Technical Preview Contents](#technical-preview-contents)
+  1. [Getting Started](#getting-started)
+  1. [Type System](#type-system)
+  1. [Query Syntax](#query-syntax)
+  1. [Validation](#alidation)
+  1. [Introspection](#introspection)
+  1. [Additional Content](#additional-content)
+
 ## Technical Preview Contents
 
 This technical preview contains a draft specification for GraphQL and a reference


### PR DESCRIPTION
Add table of contents for easier navigation.

After read some of the content one day I came back days later and wanted to just jump to the section I was looking for.