### PR TITLE
Grammar fixes and section adjustment

### DIFF
--- a/spec/Section 5 -- Validation.md
+++ b/spec/Section 5 -- Validation.md
@@ -870,7 +870,7 @@ fragment ownerFragment on Dog {
 
 ** Formal Specification **
 
-  * For each {spread} (named or inline) in defined in the document.
+  * For each {spread} (named or inline) defined in the document.
   * Let {fragment} be the target of {spread}
   * Let {fragmentType} be the type condition of {fragment}
   * Let {parentType} be the type of the selection set containing {spread}
@@ -893,7 +893,7 @@ the parent type.
 
 ##### Object Spreads In Object Scope
 
-In the scope of a object type, the only valid object type
+In the scope of an object type, the only valid object type
 fragment spread is one that applies to the same type that
 is in scope.
 
@@ -1100,8 +1100,8 @@ usage of a directive, the directive must be available on that server.
 
 ** Explanatory Text **
 
-Variable defined by operations are allowed to define default values
-if the type of that variable not non-null.
+Variables defined by operations are allowed to define default values
+if the type of that variable is not non-null.
 
 For example the following query will pass validation.
 

--- a/spec/Section 5 -- Validation.md
+++ b/spec/Section 5 -- Validation.md
@@ -1083,11 +1083,9 @@ For example the following query will not pass validation.
 GraphQL servers define what directives they support. For each
 usage of a directive, the directive must be available on that server.
 
-## Operations
+## Variables
 
-### Variables
-
-#### Variable Default Values Are Correctly Typed
+### Variable Default Values Are Correctly Typed
 
 ** Formal Specification **
 
@@ -1150,7 +1148,7 @@ query intToFloatQuery($floatVar: Float = 1) {
 }
 ```
 
-#### Variables Are Input Types
+### Variables Are Input Types
 
 ** Formal Specification **
 
@@ -1203,7 +1201,7 @@ query takesCatOrDog($catOrDog: CatOrDog) {
 }
 ```
 
-#### All Variable Uses Defined
+### All Variable Uses Defined
 
 ** Formal Specification **
 
@@ -1345,7 +1343,7 @@ This is because {housetrainedQueryTwoNotDefined} does not define
 a variable ${atOtherHomes} but that variable is used by {isHousetrainedFragment}
 which is included in that operation.
 
-#### All Variables Used
+### All Variables Used
 
 ** Formal Specification **
 
@@ -1427,7 +1425,7 @@ fragment isHousetrainedFragment on Dog {
 This document is not valid because {queryWithExtraVar} defines
 an extraneous variable.
 
-#### All Variable Usages are Allowed
+### All Variable Usages are Allowed
 
 ** Formal Specification **
 


### PR DESCRIPTION
- Fixes a few grammar issues.
- Currently in the validation section there are two subsections named "Operations" (numbered 5.1 and 5.7).  This naming collision means the skiplink in the TOC for 5.7 sends you to 5.1.  I believe the intention was to have the "Variables" section as 5.7, so I removed the second "Operations" section and adjusted the child sections accordingly.  If this isn't what was intended, let me know and I can rebase this out of the PR.