### PR TITLE
additional operation name uniqueness validation example

### DIFF
--- a/spec/Section 5 -- Validation.md
+++ b/spec/Section 5 -- Validation.md
@@ -120,6 +120,22 @@ query getName {
 }
 ```
 
+It is invalid even if the type of each operation is different:
+
+```!graphql
+query dogOperation {
+  dog {
+    name
+  }
+}
+
+mutation dogOperation {
+  mutateDog {
+    id
+  }
+}
+```
+
 ### Anonymous Operation Definitions
 
 #### Lone Anonymous Operation


### PR DESCRIPTION
Previously we didn't have an example with 2 operation that have the same name, but different type, so it wasn't clear that it is also invalid.