### PR TITLE
Union type definition must be lower case

### DIFF
--- a/spec/Section 3 -- Type System.md
+++ b/spec/Section 3 -- Type System.md
@@ -549,7 +549,7 @@ typed fragments.
 For example, we might have the following type system:
 
 ```
-Union SearchResult = Photo | Person
+union SearchResult = Photo | Person
 
 type Person {
   name: String


### PR DESCRIPTION
Minor typo in union type defition. Capitalization is significant, so `Union` has to be changed to `union`, otherwise the parser will complain.