### PR TITLE
Unifying name of Non-Null

### DIFF
--- a/spec/Section 3 -- Type System.md
+++ b/spec/Section 3 -- Type System.md
@@ -828,20 +828,20 @@ exclamation mark is used to denote a field that uses a Non-Null type like this:
 **Result Coercion**
 
 In all of the above result coercion, {null} was considered a valid value.
-To coerce the result of a Non Null type, the coercion of the wrapped type
+To coerce the result of a Non-Null type, the coercion of the wrapped type
 should be performed. If that result was not {null}, then the result of coercing
-the Non Null type is that result. If that result was {null}, then a field error
+the Non-Null type is that result. If that result was {null}, then a field error
 must be raised.
 
 **Input Coercion**
 
-If the argument of a Non Null type is not provided, a query error must
+If the argument of a Non-Null type is not provided, a query error must
 be raised.
 
-If an argument of a Non Null type is provided with a literal value, it is
+If an argument of a Non-Null type is provided with a literal value, it is
 coerced using the input coercion for the wrapped type.
 
-If the argument of a Non Null is provided with a variable, a query error must be
+If the argument of a Non-Null is provided with a variable, a query error must be
 raised if the runtime provided value is not provided or is {null} in the
 provided representation (usually JSON). Otherwise, the coerced value is the
 result of using the input coercion for the wrapped type.

--- a/spec/Section 5 -- Validation.md
+++ b/spec/Section 5 -- Validation.md
@@ -1663,7 +1663,7 @@ Variable usages must be compatible with the arguments they are passed to.
 
 Validation failures occur when variables are used in the context of types
 that are complete mismatches, or if a nullable type in a variable is passed to
-a not-null argument type.
+a non-null argument type.
 
 Types must match:
 


### PR DESCRIPTION
For better searchability, use 1 name for Non-Null.
Ignoring case, there are 12 occurrences of the phrase "Non-Null", 5 of "Non Null" and 1 of "not-null".  Side note, my chrome browser doesn't even find not-null in a search.

I have not made changes to case, as many searches are not case sensitive.