### PR TITLE
[RFC] Add error path to response

### DIFF
--- a/spec/Section 7 -- Response.md
+++ b/spec/Section 7 -- Response.md
@@ -111,6 +111,12 @@ locations, where each location is a map with the keys `line` and `column`, both
 positive numbers starting from `1` which describe the beginning of an
 associated syntax element.
 
+If an error can be associated to a particular field in the GraphQL response, it
+should contain an entry with the key `path` with a list of path segments
+starting at the root of the response and ending with the field associated with
+the error. Path segments that represent object fields should be strings, and
+path segments that represent array indices should be 0-indexed integers.
+
 GraphQL servers may provide additional entries to error as they choose to
 produce more helpful or machine-readable errors, however future versions of the
 spec may describe additional entries to errors.


### PR DESCRIPTION
Just an idea for discussion - adding the path to the response, like [this implementation in `graphql-js`](https://github.com/graphql/graphql-js/blob/1ed070fed63767e82470ca39d036539b99693c4c/src/__tests__/starWarsQuery-test.js#L438-L446):

```js
path: [ 'hero', 'friends', 0, 'secretBackstory' ]
```

Just like it is helpful to know the location in the query associated with an error, it's helpful to know the location in the response.

This is already implemented in errors thrown from resolvers in `graphql-js`, so it would just be a matter of having the right error formatting to include that information.

This would be extremely helpful to differentiate when a field is `null` in the result because the result was actually `null`, and when it is because of a runtime error in the resolver.