### PR TITLE
Correct an error in the Punctuator grammar

### DIFF
--- a/spec/Section 2 -- Language.md
+++ b/spec/Section 2 -- Language.md
@@ -141,7 +141,7 @@ white space characters are permitted between the characters defining a
 
 ### Punctuators
 
-Punctuator :: one of ! $ ( ) ... : = @ [ ] { }
+Punctuator :: one of ! $ ( ) ... : = @ [ ] { | }
 
 GraphQL documents include punctuation in order to describe structure. GraphQL
 is a data description language and not a programming language, therefore GraphQL


### PR DESCRIPTION
In Appendix B `Punctuator` includes `|`, but it was missing here.