### PR TITLE
Allow Travis CI's IRC bot to post without joining

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,7 @@ notifications:
     use_notice: true
     on_success: change
     on_failure: change
+    skip_join: true
     channels:
       - chat.freenode.net#graphql
 


### PR DESCRIPTION
Same PR than https://github.com/graphql/graphql-js/pull/514.

See https://docs.travis-ci.com/user/notifications#IRC-notification for more information.

Note that this requires removing the `n` flag on the IRC channel.
See https://freenode.net/kb/answer/channelmodes

> n (prevent external send): Users outside the channel may not send messages to it. Keep in mind that bans and quiets will not apply to external users.