### PR TITLE
[RFC] No ignored within Variables.

### DIFF
--- a/spec/Appendix B -- Grammar Summary.md
+++ b/spec/Appendix B -- Grammar Summary.md
@@ -152,7 +152,7 @@ VariableDefinitions : ( VariableDefinition+ )
 
 VariableDefinition : Variable : Type DefaultValue?
 
-Variable : $ Name
+Variable : $ [lookahead ! Ignored] Name
 
 DefaultValue : = Value[Const]
 

--- a/spec/Section 2 -- Language.md
+++ b/spec/Section 2 -- Language.md
@@ -855,7 +855,7 @@ ObjectValue : { ObjectField+ }
 
 ## Variables
 
-Variable : $ Name
+Variable : $ [lookahead ! Ignored] Name
 
 VariableDefinitions : ( VariableDefinition+ )
 


### PR DESCRIPTION
This adds a specific limitation to the Variable parsing rules to make it impossible to put ignored characters between the `$` and the name of the variable.

This was suggested by @martijnwalraven as he was building syntax highlighters for some IDEs.

I'm not sure if this is necessary or good - but wanted to capture it so we can have a conversation about it.

To be specific about the issue and the impact of this change, currently the following are legal variables:

``` graphql
$variable

$ variable

$
variable

$       variable

$,,,variable
```

With this change, only `$variable` will be a parsable Variable form, the others with ignored characters will not be allowed.
