### PR TITLE
[RFC] Add error path to response

### DIFF
--- a/spec/Section 7 -- Response.md
+++ b/spec/Section 7 -- Response.md
@@ -217,6 +217,13 @@ be the same:
 
 ```js
 {
+  "errors": [
+    {
+      "message": "Name for character with ID 1002 could not be fetched.",
+      "locations": [ { "line": 6, "column": 7 } ],
+      "path": [ "hero", "heroFriends", 1, "name" ]
+    }
+  ],
   "data": {
     "hero": {
       "name": "R2-D2",
@@ -232,14 +239,7 @@ be the same:
         }
       ]
     }
-  },
-  "errors": [
-    {
-      "message": "Name for character with ID 1002 could not be fetched.",
-      "locations": [ { "line": 6, "column": 7 } ],
-      "path": [ "hero", "heroFriends", 1, "name" ]
-    }
-  ]
+  }
 }
 ```
 

--- a/spec/Section 7 -- Response.md
+++ b/spec/Section 7 -- Response.md
@@ -147,7 +147,8 @@ associated syntax element.
 
 If an error can be associated to a particular field in the GraphQL result, it
 should contain an entry with the key `path` that details the path of the
-response field which experienced the error.
+response field which experienced the error. This allows clients to identify
+whether a `null` result is intentional or caused by a runtime error.
 
 This field should be a list of path segments starting at the root of the
 response and ending with the field associated with the error. Path segments

--- a/spec/Section 7 -- Response.md
+++ b/spec/Section 7 -- Response.md
@@ -177,6 +177,13 @@ The response might look like:
 
 ```js
 {
+  "errors": [
+    {
+      "message": "Name for character with ID 1002 could not be fetched.",
+      "locations": [ { "line": 6, "column": 7 } ],
+      "path": [ "hero", "heroFriends", 1, "name" ]
+    }
+  ],
   "data": {
     "hero": {
       "name": "R2-D2",
@@ -195,14 +202,7 @@ The response might look like:
         }
       ]
     }
-  },
-  "errors": [
-    {
-      "message": "Name for character with ID 1002 could not be fetched.",
-      "locations": [ { "line": 6, "column": 7 } ],
-      "path": [ "hero", "heroFriends", 1, "name" ]
-    }
-  ]
+  }
 }
 ```
 

--- a/spec/Section 7 -- Response.md
+++ b/spec/Section 7 -- Response.md
@@ -155,7 +155,7 @@ response and ending with the field associated with the error. Path segments
 that represent object fields should be strings, and path segments that
 represent array indices should be 0-indexed integers. If the error happens
 in an aliased field, the path to the error should use the aliased name, since
-it represents a path in the response, not than the query.
+it represents a path in the response, not in the query.
 
 For example, if fetching one of the friends' names fails in the following
 query:

--- a/spec/Section 7 -- Response.md
+++ b/spec/Section 7 -- Response.md
@@ -146,13 +146,15 @@ positive numbers starting from `1` which describe the beginning of an
 associated syntax element.
 
 If an error can be associated to a particular field in the GraphQL result, it
-should contain an entry with the key `path` with a list of path segments
-starting at the root of the response and ending with the field associated with
-the error. Path segments that represent object fields should be strings, and
-path segments that represent array indices should be 0-indexed integers.
+should contain an entry with the key `path` that details the path of the
+response field which experienced the error.
 
-If the error happens in an aliased field, the path to the error should use the
-aliased name, since it represents a path in the response, not than the query.
+This field should be a list of path segments starting at the root of the
+response and ending with the field associated with the error. Path segments
+that represent object fields should be strings, and path segments that
+represent array indices should be 0-indexed integers. If the error happens
+in an aliased field, the path to the error should use the aliased name, since
+it represents a path in the response, not than the query.
 
 For example, if fetching one of the friends' names fails in the following
 query:

--- a/spec/Section 7 -- Response.md
+++ b/spec/Section 7 -- Response.md
@@ -210,6 +210,38 @@ result will bubble up to the next nullable field. In that case, the `path`
 for the error should include the full path to the result field where the error
 occurred, even if that field is not present in the response.
 
+For example, if the `name` field from above had declared a `Non-Null` return
+type in the schema, the result would look different but the error reported would
+be the same:
+
+```js
+{
+  "data": {
+    "hero": {
+      "name": "R2-D2",
+      "heroFriends": [
+        {
+          "id": "1000",
+          "name": "Luke Skywalker"
+        },
+        null,
+        {
+          "id": "1003",
+          "name": "Leia Organa"
+        }
+      ]
+    }
+  },
+  "errors": [
+    {
+      "message": "Name for character with ID 1002 could not be fetched.",
+      "locations": [ { "line": 6, "column": 7 }],
+      "path": [ "hero", "heroFriends", 1, "name" ]
+    }
+  ]
+}
+```
+
 GraphQL servers may provide additional entries to error as they choose to
 produce more helpful or machine-readable errors, however future versions of the
 spec may describe additional entries to errors.

--- a/spec/Section 7 -- Response.md
+++ b/spec/Section 7 -- Response.md
@@ -146,7 +146,7 @@ positive numbers starting from `1` which describe the beginning of an
 associated syntax element.
 
 If an error can be associated to a particular field in the GraphQL result, it
-should contain an entry with the key `path` that details the path of the
+must contain an entry with the key `path` that details the path of the
 response field which experienced the error. This allows clients to identify
 whether a `null` result is intentional or caused by a runtime error.
 

--- a/spec/Section 7 -- Response.md
+++ b/spec/Section 7 -- Response.md
@@ -125,13 +125,14 @@ error is a map.
 If no errors were encountered during the requested operation, the `errors`
 entry should not be present in the result.
 
-If the `data` entry in the response is `null` or not present, the `errors`
+If the `data` entry in the response is not present, the `errors`
 entry in the response must not be empty. It must contain at least one error.
 The errors it contains should indicate why no data was able to be returned.
 
-If the `data` entry in the response is not `null`, the `errors` entry in the
-response may contain any errors that occurred during execution. If errors
-occurred during execution, it should contain those errors.
+If the `data` entry in the response is present (including if it is the value 
+{null}), the `errors` entry in the response may contain any errors that 
+occurred during execution. If errors occurred during execution, it should 
+contain those errors.
 
 **Error result format**
 

--- a/spec/Section 7 -- Response.md
+++ b/spec/Section 7 -- Response.md
@@ -135,6 +135,12 @@ locations, where each location is a map with the keys `line` and `column`, both
 positive numbers starting from `1` which describe the beginning of an
 associated syntax element.
 
+If an error can be associated to a particular field in the GraphQL response, it
+should contain an entry with the key `path` with a list of path segments
+starting at the root of the response and ending with the field associated with
+the error. Path segments that represent object fields should be strings, and
+path segments that represent array indices should be 0-indexed integers.
+
 GraphQL servers may provide additional entries to error as they choose to
 produce more helpful or machine-readable errors, however future versions of the
 spec may describe additional entries to errors.

--- a/spec/Section 7 -- Response.md
+++ b/spec/Section 7 -- Response.md
@@ -199,7 +199,7 @@ The response might look like:
     {
       "message": "Name for character with ID 1002 could not be fetched.",
       "locations": [ { "line": 6, "column": 7 }],
-      "path": [ "hero", "heroFriends", 3, "name" ]
+      "path": [ "hero", "heroFriends", 1, "name" ]
     }
   ]
 }

--- a/spec/Section 7 -- Response.md
+++ b/spec/Section 7 -- Response.md
@@ -152,8 +152,8 @@ whether a `null` result is intentional or caused by a runtime error.
 
 This field should be a list of path segments starting at the root of the
 response and ending with the field associated with the error. Path segments
-that represent object fields should be strings, and path segments that
-represent array indices should be 0-indexed integers. If the error happens
+that represent fields should be strings, and path segments that
+represent list indices should be 0-indexed integers. If the error happens
 in an aliased field, the path to the error should use the aliased name, since
 it represents a path in the response, not in the query.
 
@@ -198,7 +198,7 @@ The response might look like:
   "errors": [
     {
       "message": "Name for character with ID 1002 could not be fetched.",
-      "locations": [ { "line": 6, "column": 7 }],
+      "locations": [ { "line": 6, "column": 7 } ],
       "path": [ "hero", "heroFriends", 1, "name" ]
     }
   ]
@@ -235,7 +235,7 @@ be the same:
   "errors": [
     {
       "message": "Name for character with ID 1002 could not be fetched.",
-      "locations": [ { "line": 6, "column": 7 }],
+      "locations": [ { "line": 6, "column": 7 } ],
       "path": [ "hero", "heroFriends", 1, "name" ]
     }
   ]


### PR DESCRIPTION
Reopening from https://github.com/facebook/graphql/pull/187 with a real branch.

This is helpful for clients to identify why there is a `null` in the response, because that could be due to an error or an actual `null` result.