### PR TITLE
Clarify: Adds more mentions of `__` as reserved by introspection system.

### DIFF
--- a/spec/Section 3 -- Type System.md
+++ b/spec/Section 3 -- Type System.md
@@ -22,6 +22,10 @@ any built in types (including Scalar and Introspection types).
 All directives within a GraphQL schema must have unique names. A directive
 and a type may share the same name, since there is no ambiguity between them.
 
+All types and directives defined within a schema must not have a name which
+begins with {"__"} (two underscores), as this is used exclusively by GraphQL's
+introspection system.
+
 
 ## Types
 
@@ -255,6 +259,10 @@ a specific type. Object values should be serialized as ordered maps, where the
 queried field names (or aliases) are the keys and the result of evaluating
 the field is the value, ordered by the order in which they appear in the query.
 
+All fields defined within an Object type must not have a name which begins with
+{"__"} (two underscores), as this is used exclusively by GraphQL's
+introspection system.
+
 For example, a type `Person` could be described as:
 
 ```
@@ -475,6 +483,10 @@ fields can accept arguments to further specify the return value. Object field
 arguments are defined as a list of all possible argument names and their
 expected input types.
 
+All arguments defined within a field must not have a name which begins with
+{"__"} (two underscores), as this is used exclusively by GraphQL's
+introspection system.
+
 For example, a `Person` type with a `picture` field could accept an argument to
 determine what size of an image to return.
 
@@ -525,7 +537,9 @@ of rules must be adhered to by every Object type in a GraphQL schema.
 1. An Object type must define one or more fields.
 2. The fields of an Object type must have unique names within that Object type;
    no two fields may share the same name.
-3. An object type must be a super-set of all interfaces it implements:
+3. Each field of an Object type must not have a name which begins with the
+   characters {"__"} (two underscores).
+4. An object type must be a super-set of all interfaces it implements:
    1. The object type must include a field of the same name for every field
       defined in an interface.
       1. The object field must be of a type which is equal to or a sub-type of
@@ -653,6 +667,8 @@ Interface types have the potential to be invalid if incorrectly defined.
 1. An Interface type must define one or more fields.
 2. The fields of an Interface type must have unique names within that Interface
    type; no two fields may share the same name.
+3. Each field of an Interface type must not have a name which begins with the
+   characters {"__"} (two underscores).
 
 
 ### Unions

--- a/spec/Section 4 -- Introspection.md
+++ b/spec/Section 4 -- Introspection.md
@@ -63,9 +63,9 @@ would return
 ### Naming conventions
 
 Types and fields required by the GraphQL introspection system that are used in
-the same context as user-defined types and fields are prefixed with two
+the same context as user-defined types and fields are prefixed with {"__"} two
 underscores. This in order to avoid naming collisions with user-defined GraphQL
-types.  Conversely, GraphQL type system authors must not define any types,
+types. Conversely, GraphQL type system authors must not define any types,
 fields, arguments, or any other type system artifact with two leading
 underscores.
 


### PR DESCRIPTION
The spec chapter on introspection mentions that type artifacts must not be named with "__" since it is reserved. This clarification repeats this information closer to the spec on type system itself along with the rules for determining if object/interface types are valid.