### PR TITLE
Fixed minor typo: 'interpretted'

### DIFF
--- a/spec/Section 3 -- Type System.md
+++ b/spec/Section 3 -- Type System.md
@@ -888,7 +888,7 @@ argument is passed (a common case), the client can just pass that value rather
 than constructing the list.
 
 Note that when a {null} value is provided via a runtime variable value for a
-list type that it is interpretted as no list being provided, and not a list of
+list type that it is interpreted as no list being provided, and not a list of
 size one with the value {null}.
 
 


### PR DESCRIPTION
Minor typo correction, from 'interpretted' to 'interpret'.

For further consideration: would it possible to re-consider the entire sentence? Currently, it is not easy to read.

Current (with typo change)
> Note that when a {null} value is provided via a runtime variable value for a
list type that it is interpreted as no list being provided, and not a list of
size one with the value {null}.

Possible change:
> Note that when a {null} value is provided via a runtime variable value for a
list type, the value is interpreted as no list being provided, and not a list of
size one with the value {null}.

Open to discussion.

Cheers!