### PR TITLE
Improved note on input coercion for null value via runtime variable value

### DIFF
--- a/spec/Section 3 -- Type System.md
+++ b/spec/Section 3 -- Type System.md
@@ -888,7 +888,7 @@ argument is passed (a common case), the client can just pass that value rather
 than constructing the list.
 
 Note that when a {null} value is provided via a runtime variable value for a
-list type that it is interpreted as no list being provided, and not a list of
+list type, the value is interpreted as no list being provided, and not a list of
 size one with the value {null}.
 
 


### PR DESCRIPTION
Follow-up to #260

Improved the note on input coercion for null value via runtime variable value for a list type.

The previous form was a little bit hard to read. Hopefully the changes improve its readability.

Thanks!