### PR TITLE
Forbid to implement same same interface twice

### DIFF
--- a/spec/Section 3 -- Type System.md
+++ b/spec/Section 3 -- Type System.md
@@ -539,7 +539,8 @@ of rules must be adhered to by every Object type in a GraphQL schema.
    no two fields may share the same name.
 3. Each field of an Object type must not have a name which begins with the
    characters {"__"} (two underscores).
-4. An object type must be a super-set of all interfaces it implements:
+4. An object type may declare that it implements one or more unique interfaces.
+5. An object type must be a super-set of all interfaces it implements:
    1. The object type must include a field of the same name for every field
       defined in an interface.
       1. The object field must be of a type which is equal to or a sub-type of


### PR DESCRIPTION
Both spec and reference implementation allow you to implement the same interface twice:
```
type Cat implements Pet, Pet {
  name: String
  currentlyPurring: Boolean
}
```

Moreover, I've discovered this issue in production GitHub's GraphQL API
![image](https://cloud.githubusercontent.com/assets/8336157/22611778/3d9b3f54-ea75-11e6-8ed9-acbe3a9964f3.png)