### PR TITLE
Forbid to define duplicated member types in Union

### DIFF
--- a/spec/Section 3 -- Type System.md
+++ b/spec/Section 3 -- Type System.md
@@ -752,7 +752,7 @@ Union types have the potential to be invalid if incorrectly defined.
 1. The member types of a Union type must all be Object base types;
    Scalar, Interface and Union types may not be member types of a Union.
    Similarly, wrapping types may not be member types of a Union.
-2. A Union type must define one or more member types.
+2. A Union type must define one or more unique member types.
 
 ### Enums
 


### PR DESCRIPTION
This PR is intended to prevent a problem similar to #262 but for Union types.
