### PR TITLE
Forbid alias names to start with `__`

### DIFF
--- a/spec/Section 5 -- Validation.md
+++ b/spec/Section 5 -- Validation.md
@@ -212,7 +212,8 @@ query getName {
 **Explanatory Text**
 
 The target field of a field selection must be defined on the scoped type of the
-selection set. There are no limitations on alias names.
+selection set. Alias names must not begin with {"__"} (two underscores), as they
+can conflict with names used by GraphQL's introspection system.
 
 For example the following fragment would not pass validation:
 


### PR DESCRIPTION
In on of our application, we need to know the exact type of every object in response so we inject `__typename` into every selection. 
According to the current version of the spec, following query is valid:
```
{
   __typename: someField
}
```
So injected selection will look like:
```
{
   __typename: someField
   __typename
}
```
And will produce the following error:
```
"Fields \"__typename\" conflict because someField and __typename are different fields. Use different aliases on the fields to fetch both if this was intentional."
```
Based on [this line](https://github.com/facebook/relay/blame/45fd7206f8e003d283acf7ef5462731176cfd04f/CHANGELOG.md#L182) and a quick look through source code I suspect that Relay also injects `__typename` into queries and therefore is also affected by the same problem.
