### PR TITLE
Use common Markdown for descriptions

### DIFF
--- a/spec/Section 4 -- Introspection.md
+++ b/spec/Section 4 -- Introspection.md
@@ -74,9 +74,10 @@ underscores.
 
 All types in the introspection system provide a `description` field of type
 `String` to allow type designers to publish documentation in addition to
-capabilities. A GraphQL server may return the `description` field using 
-[Common Markdown](http://spec.commonmark.org/) syntax. Therefore it is recommended
-that any tool that displays description use a Common Markdown compliant renderer.
+capabilities. A GraphQL server may return the `description` field using Markdown
+syntax (as specified by [CommonMark](http://commonmark.org/)). Therefore it is
+recommended that any tool that displays `description` use a CommonMark-compliant
+Markdown renderer.
 
 
 ### Deprecation

--- a/spec/Section 4 -- Introspection.md
+++ b/spec/Section 4 -- Introspection.md
@@ -74,9 +74,9 @@ underscores.
 
 All types in the introspection system provide a `description` field of type
 `String` to allow type designers to publish documentation in addition to
-capabilities. A GraphQL server may return the `description` field using Markdown
-syntax. Therefore it is recommended that any tool that displays description
-use a Markdown renderer.
+capabilities. A GraphQL server may return the `description` field using 
+[Common Markdown](http://spec.commonmark.org/) syntax. Therefore it is recommended
+that any tool that displays description use a Common Markdown compliant renderer.
 
 
 ### Deprecation


### PR DESCRIPTION
There are a lot of different Markdown dialects. Let's stick to Common Markdown as it was recently done by GitHub and others.
I believe most of markdown renderers will support soon or already support Common Markdown.