### PR TITLE
Clarify how operation name is handled in the spec.

### DIFF
--- a/spec/Section 2 -- Language.md
+++ b/spec/Section 2 -- Language.md
@@ -184,7 +184,7 @@ represented in the shorthand form, which omits both the query keyword and
 operation name. Otherwise, if a GraphQL query document contains multiple
 operations, each operation must be named. When submitting a query document with
 multiple operations to a GraphQL service, the name of the desired operation to
-be executed must also be provided.
+be executed must also be provided. How the name is provided is up to the GraphQL implementation.
 
 
 ## Operations

--- a/spec/Section 6 -- Execution.md
+++ b/spec/Section 6 -- Execution.md
@@ -22,7 +22,7 @@ to be formatted according to the Response section below.
 To execute a request, the executor must have a parsed `Document` (as defined
 in the “Query Language” part of this spec) and a selected operation name to
 run if the document defines multiple operations, otherwise the document is
-expected to only contain a single operation. The result of the request is
+expected to only contain a single operation. How this information is passed to the executor is determined by the implementation. The result of the request is
 determined by the result of executing this operation according to the "Executing
 Operations” section below.
 


### PR DESCRIPTION
As #292 I believe it will be beneficial to clarify that
specifying the operation name when handling multiple operations
is up to the implementation, not the query language.