### PR TITLE
Spec: Formal Subscriptions Definition

### DIFF
--- a/spec/Appendix B -- Grammar Summary.md
+++ b/spec/Appendix B -- Grammar Summary.md
@@ -94,7 +94,7 @@ OperationDefinition :
   - SelectionSet
   - OperationType Name? VariableDefinitions? Directives? SelectionSet
 
-OperationType : one of query mutation
+OperationType : one of query mutation subscription
 
 SelectionSet : { Selection+ }
 

--- a/spec/Section 2 -- Language.md
+++ b/spec/Section 2 -- Language.md
@@ -2,7 +2,7 @@
 
 Clients use the GraphQL query language to make requests to a GraphQL service.
 We refer to these request sources as documents. A document may contain
-operations (queries and mutations are both operations) as well as fragments, a
+operations (queries, mutations, and subscriptions) as well as fragments, a
 common unit of composition allowing for query reuse.
 
 A GraphQL document is defined as a syntactic grammar where terminal symbols are
@@ -193,12 +193,14 @@ OperationDefinition :
   - OperationType Name? VariableDefinitions? Directives? SelectionSet
   - SelectionSet
 
-OperationType : one of `query` `mutation`
+OperationType : one of `query` `mutation` `subscription`
 
-There are two types of operations that GraphQL models:
+There are three types of operations that GraphQL models:
 
   * query - a read-only fetch.
   * mutation - a write followed by a fetch.
+  * subscription - a long-lived request that returns data whenever a domain
+    event triggers.
 
 Each operation is represented by an optional operation name and a selection set.
 

--- a/spec/Section 2 -- Language.md
+++ b/spec/Section 2 -- Language.md
@@ -199,8 +199,8 @@ There are three types of operations that GraphQL models:
 
   * query - a read-only fetch.
   * mutation - a write followed by a fetch.
-  * subscription - a long-lived request that returns data whenever a domain
-    event triggers.
+  * subscription - a long-lived request that fetches data in response to source
+    events.
 
 Each operation is represented by an optional operation name and a selection set.
 

--- a/spec/Section 3 -- Type System.md
+++ b/spec/Section 3 -- Type System.md
@@ -12,8 +12,8 @@ A given GraphQL schema must itself be internally valid. This section describes
 the rules for this validation process where relevant.
 
 A GraphQL schema is represented by a root type for each kind of operation:
-query and mutation; this determines the place in the type system where those
-operations begin.
+query, mutation, and subscription; this determines the place in the type system
+where those operations begin.
 
 All types within a GraphQL schema must have unique names. No two provided types
 may have the same name. No provided type may have a name which conflicts with
@@ -1013,12 +1013,14 @@ must *not* be queried if either the `@skip` condition is true *or* the
 
 ## Initial types
 
-A GraphQL schema includes types, indicating where query and mutation
-operations start. This provides the initial entry points into the
+A GraphQL schema includes types, indicating where query, mutation, and
+subscription operations start. This provides the initial entry points into the
 type system. The query type must always be provided, and is an Object
 base type. The mutation type is optional; if it is null, that means
 the system does not support mutations. If it is provided, it must
-be an object base type.
+be an object base type. Similarly, the subscription type is optional; if it is
+null, the system does not support subscriptions. If it is provided, it must be
+an object base type.
 
 The fields on the query type indicate what fields are available at
 the top level of a GraphQL query. For example, a basic GraphQL query
@@ -1043,3 +1045,14 @@ mutation setName {
 
 Is valid when the type provided for the mutation starting type is not null,
 and has a field named "setName" with a string argument named "name".
+
+```graphql
+subscription {
+  newMessage {
+    text
+  }
+}
+```
+
+Is valid when the type provided for the subscription starting type is not null,
+and has a field named "newMessage" and only contains a single root field. 

--- a/spec/Section 4 -- Introspection.md
+++ b/spec/Section 4 -- Introspection.md
@@ -124,6 +124,7 @@ type __Schema {
   types: [__Type!]!
   queryType: __Type!
   mutationType: __Type
+  subscriptionType: __Type
   directives: [__Directive!]!
 }
 
@@ -195,6 +196,7 @@ type __Directive {
 enum __DirectiveLocation {
   QUERY
   MUTATION
+  SUBSCRIPTION
   FIELD
   FRAGMENT_DEFINITION
   FRAGMENT_SPREAD

--- a/spec/Section 5 -- Validation.md
+++ b/spec/Section 5 -- Validation.md
@@ -198,6 +198,70 @@ query getName {
 }
 ```
 
+### Subscription Operation Definitions
+
+#### Single root field
+
+**Formal Specification**
+
+  * For each subscription operation definition {subscription} in the document
+  * Let {rootFields} be the first level of fields on the operation's selection set.
+    * {rootFields} must be a set of one.
+
+**Explanatory Text**
+
+Subscription operation must have exactly one root field.
+
+Valid examples:
+
+```graphql
+subscription sub {
+  newMessage {
+    body
+    sender
+  }
+}
+```
+
+```graphql
+fragment newMessageFields on Message {
+  body
+  sender
+}
+
+subscription sub {
+  newMessage {
+    ... newMessageFields  
+  }
+}
+```
+
+Invalid:
+
+```!graphql
+subscription sub {
+  newMessage {
+    body
+    sender
+  }
+  # a second root field will cause this operation to fail validation
+  alarms {
+    name
+    snoozeCount
+  }
+}
+```
+
+```!graphql
+subscription sub {
+  newMessage {
+    body
+    sender
+  }
+  # this also applies to introspection fields
+  __typename
+}
+```
 
 ## Fields
 

--- a/spec/Section 5 -- Validation.md
+++ b/spec/Section 5 -- Validation.md
@@ -210,7 +210,7 @@ query getName {
 
 **Explanatory Text**
 
-Subscription operation must have exactly one root field.
+Subscription operations must have exactly one root field.
 
 Valid examples:
 

--- a/spec/Section 5 -- Validation.md
+++ b/spec/Section 5 -- Validation.md
@@ -244,13 +244,11 @@ subscription sub {
     body
     sender
   }
-  # a second root field will cause this operation to fail validation
-  alarms {
-    name
-    snoozeCount
-  }
+  disallowedSecondRootField
 }
 ```
+
+Introspection fields are counted. The following example is also invalid:
 
 ```!graphql
 subscription sub {
@@ -258,7 +256,6 @@ subscription sub {
     body
     sender
   }
-  # this also applies to introspection fields
   __typename
 }
 ```

--- a/spec/Section 5 -- Validation.md
+++ b/spec/Section 5 -- Validation.md
@@ -205,7 +205,7 @@ query getName {
 **Formal Specification**
 
   * For each subscription operation definition {subscription} in the document
-  * Let {rootFields} be the first level of fields on the operation's selection set.
+  * Let {rootFields} be the top level selection set on {subscription}.
     * {rootFields} must be a set of one.
 
 **Explanatory Text**

--- a/spec/Section 6 -- Execution.md
+++ b/spec/Section 6 -- Execution.md
@@ -154,7 +154,8 @@ the following capabilities:
   * **must** support observation of the associated publish stream (for example,
   via iteration, callbacks, or reactive semantics).
   * **must** support cancellation of the subscription (aka unsubscribe).
-  * **must** support a unique mapping to the subscriber (for example, a unique Id).
+  * **must** support a way to identify the subscriber/subscription pair (for
+    example, a GUID/callback table or closure over the callback).
   * **may** include an initial response associated with executing the selection
   set defined on the subscription operation.
 
@@ -182,11 +183,16 @@ Publish(subscription, schema, variableValues, payload, publishStream)
       {publishStream}.
 
 ### Unsubscribe
+The unsubscribe operation can be implemented in a number of ways. For example,
+by using a dedicated subscription manager, defining it as a method on the
+subscription object, or cancelling the iterator.
+
 Unsubscribe()
 
   * Let {publishStream} be a mapping of {null}
+  * Terminate and clean up {eventStream}
 
-### Recommendations and Considerations for supporting Subscriptions
+### Recommendations and Considerations for Supporting Subscriptions
 Supporting subscriptions is a large change for any GraphQL server. Query and
 mutation operations are stateless, allowing scaling via cloning GraphQL server
 instances. Subscriptions, by contrast, are stateful. The pieces of state for a
@@ -202,10 +208,11 @@ We recommend thinking about the behavior of your system when this state is lost
 due to single-node failures. We can improve durability and availability by using
 dedicated sub-systems to manage this state. For example, event streams can be
 built using modern pub-sub systems, and client channels can be handled with a
-dedicate client gateway.
+dedicated client gateway.
 
-Rather than mixing stateful and stateless systems, we recommend keeping the
-GraphQL server stateless and delegating all state persistence these sub-systems.
+Rather than mixing stateless (queries and mutations) and stateful
+(subscriptions), we recommend keeping the GraphQL server stateless and
+delegating all state persistence these sub-systems.
 
 ## Executing Selection Sets
 

--- a/spec/Section 6 -- Execution.md
+++ b/spec/Section 6 -- Execution.md
@@ -166,15 +166,19 @@ Subscribe(subscription, schema, variableValues, initialValue):
   * Assert: {subscriptionType} is an Object type.
   * Let {selectionSet} be the top level Selection Set in {subscription}.
   * Let {rootField} be the first top level field in {selectionSet}.
-  * Let {eventStream} be a domain-specific transform of {rootField, variableValues}
+  * Let {eventStream} be the result of running {MapSubscriptionEvents(rootField, variableValues)}.
   * Let {publishStream} be a mapping of {eventStream} where each {event} is
     mapped via Publish().
+
+MapSubscriptionEvents(rootField, variableValues):
+
+  * *Application-specific logic to map from root field/variables to events*
 
 ### Publish
 
 Publish(subscription, schema, variableValues, payload, publishStream)
 
-  * For each {event, payload} in {eventStream}
+  * For each {eventStream} as {event} and {payload}:
     * Let {data} be the result of running
       {ExecuteSelectionSet(selectionSet, subscriptionType, payload, variableValues)}
       *normally* (allowing parallelization).

--- a/spec/Section 6 -- Execution.md
+++ b/spec/Section 6 -- Execution.md
@@ -229,8 +229,8 @@ subscription NewMessages {
 ```
 
 While the client is subscribe, whenever new messages are posted to chat room
-with ```ID 123```, the selection for ```sender``` and ```text``` will be
-evaluated and published to the client, for example:
+with ID "123", the selection for "sender" and "text" will be evaluated and
+published to the client, for example:
 
 ```js
 {
@@ -265,7 +265,7 @@ handled by a dedicated client gateway tier.
 For systems with high capacity, availability, and durability requirements, we
 recommend keeping the GraphQL server stateless and delegating all state
 persistence to sub-systems that are designed for stateful scaling. Note that
-subscription types are still defined in the original schema along with queries 
+subscription types are still defined in the original schema along with queries
 and mutations.
 
 ## Executing Selection Sets

--- a/spec/Section 6 -- Execution.md
+++ b/spec/Section 6 -- Execution.md
@@ -106,7 +106,7 @@ Note: This algorithm is very similar to {CoerceArgumentValues()}.
 
 The type system, as described in the “Type System” section of the spec, must
 provide a query root object type. If mutations or subscriptions are supported,
-it must also provide a mutation and subscription root object type, respectively.
+it must also provide a mutation or subscription root object type, respectively.
 
 ### Query
 

--- a/spec/Section 6 -- Execution.md
+++ b/spec/Section 6 -- Execution.md
@@ -148,6 +148,7 @@ phases. Between the the subscribe and unsubscribe phases, the subscription is
 considered to be in the "active" state.
 
 ### Subscribe
+
 The result of executing a subscription operation is a subscription object with
 the following capabilities:
 
@@ -170,6 +171,7 @@ Subscribe(subscription, schema, variableValues, initialValue):
     mapped via Publish().
 
 ### Publish
+
 Publish(subscription, schema, variableValues, payload, publishStream)
 
   * For each {event, payload} in {eventStream}
@@ -183,6 +185,7 @@ Publish(subscription, schema, variableValues, payload, publishStream)
       {publishStream}.
 
 ### Unsubscribe
+
 The unsubscribe operation can be implemented in a number of ways. For example,
 by using a dedicated subscription manager, defining it as a method on the
 subscription object, or cancelling the iterator.
@@ -193,6 +196,7 @@ Unsubscribe()
   * Terminate and clean up {eventStream}
 
 ### Recommendations and Considerations for Supporting Subscriptions
+
 Supporting subscriptions is a large change for any GraphQL server. Query and
 mutation operations are stateless, allowing scaling via cloning GraphQL server
 instances. Subscriptions, by contrast, are stateful. The pieces of state for a

--- a/spec/Section 6 -- Execution.md
+++ b/spec/Section 6 -- Execution.md
@@ -161,10 +161,18 @@ the following capabilities:
   * **Must** support observation of the associated publish stream (for example,
   via iteration, callbacks, or reactive semantics).
   * **Must** support cancellation of the subscription, see {Unsubscribe}.
-  * **Must** support a way to identify the subscriber/subscription pair (for
-    example, a GUID/callback table or closure over the callback).
+  * **Must** support a way to send data to the subscriber.
   * **May** include an initial response associated with executing the selection
   set defined on the subscription operation.
+
+Most subscriptions can only be evaluated when event data is available. For
+example, a subscription tells us when users log on and off would require event
+data that tells us *who* logged on or off. Without this event data, the
+subscription cannot be evaluated. However, it is possible to define
+subscriptions that can be evaluated without event data (for example, the current
+time on the server, synthetically triggered every second). Subscriptions that do
+not require event data for evaluation can optionally return an initial response
+to the Subscribe() operation.
 
 Subscribe(schema, subscription, operationName, variableValues, initialValue):
 
@@ -185,9 +193,9 @@ Once a subscription is active, we listen for events on its event stream. Each
 event carries an optional payload, which we combine with the arguments from
 Subscribe() to resolve the selection set.
 
-  * For each {event} and {payload} on {eventStream}:
+  * For each {event} and {eventData} on {eventStream}:
     * Let {data} be the result of running
-      {ExecuteSelectionSet(selectionSet, subscriptionType, payload, variableValues)}
+      {ExecuteSelectionSet(selectionSet, subscriptionType, eventData, variableValues)}
       *normally* (allowing parallelization).
     * Let {errors} be any *field errors* produced while executing the
       selection set.

--- a/spec/Section 6 -- Execution.md
+++ b/spec/Section 6 -- Execution.md
@@ -168,6 +168,8 @@ Note: In large scale subscription systems, the {Subscribe} and {ExecuteSubscript
 algorithms may be run on separate services to maintain predictable scaling 
 properties. See the section below on Supporting Subscriptions at Scale.
 
+**Event Streams**
+
 An event stream represents a sequence of discrete events over time which can be
 observed. As an example, a "Pub-Sub" system may produce an event stream when
 "subscribing to a topic", with an event occurring on that event stream for each

--- a/spec/Section 6 -- Execution.md
+++ b/spec/Section 6 -- Execution.md
@@ -143,13 +143,6 @@ ExecuteMutation(mutation, schema, variableValues, initialValue):
     selection set.
   * Return an unordered map containing {data} and {errors}.
 
-If the operation is a subscription, the result of the operation is a subscription
-object that supports these two operations:
-
-  * observation of the event stream, for example via iteration, callbacks, or
-    observables.
-  * unsubscribe, which halts the event stream.
-
 Unlike queries and mutations, subscriptions have a lifetime that consists of three
 phases. Between the the subscribe and unsubscribe phases, the subscription is
 considered to be in the "active" state.

--- a/spec/Section 6 -- Execution.md
+++ b/spec/Section 6 -- Execution.md
@@ -41,11 +41,7 @@ GetOperation(document, operationName):
 
   * If {operationName} is {null}:
     * If {document} contains exactly one operation.
-      * Let {operation} be the Operation contained in the {document}.
-      * If {operation} is a subscription operation:
-        * If {operation} contains more than one root field, produce a query error.
-        * Return {operation}.
-      * Otherwise return {operation}.
+      * Return the Operation contained in the {document}.
     * Otherwise produce a query error requiring {operationName}.
   * Otherwise:
     * Let {operation} be the Operation named {operationName} in {document}.


### PR DESCRIPTION
This PR contains my proposal for formally describing GraphQL Subscriptions in the Spec. It will be accompanied by a PR against GraphQL-js (will provide link when that PR is available). 