### PR TITLE
Remove wrong Input Object coercion example

### DIFF
--- a/spec/Section 3 -- Type System.md
+++ b/spec/Section 3 -- Type System.md
@@ -837,7 +837,6 @@ input ExampleInputObject {
 Original Value          | Variables       | Coerced Value
 ----------------------- | --------------- | -----------------------------------
 `{ a: "abc", b: 123 }`  | {null}          | `{ a: "abc", b: 123 }`
-`{ a: 123, b: "123" }`  | {null}          | `{ a: "123", b: 123 }`
 `{ a: "abc" }`          | {null}          | Error: Missing required field {b}
 `{ a: "abc", b: null }` | {null}          | Error: {b} must be non-null.
 `{ a: null, b: 1 }`     | {null}          | `{ a: null, b: 1 }`


### PR DESCRIPTION
The second line doesn't work: the types are wrong and it will produce an error. (See https://launchpad.graphql.com/z9ql4jq47)