### PR TITLE
Clarify handling of null handling within lists

### DIFF
--- a/spec/Section 6 -- Execution.md
+++ b/spec/Section 6 -- Execution.md
@@ -694,8 +694,9 @@ to {null}, otherwise if it is a `Non-Null` type, the field error is further
 propagated to it's parent field.
 
 If a `List` type wraps a `Non-Null` type, and one of the elements of that list
-resolves to {null}, then the entire list must resolve to {null}, and propagate the
-field error up if the list is marked `Non-Null` as well.
+resolves to {null}, then the entire list must resolve to {null}. 
+If the `List` type is also wrapped in a `Non-Null`, the field error continues 
+to propagate upwards.
 
 If all fields from the root of the request to the source of the error return
 `Non-Null` types, then the {"data"} entry in the response should be {null}.

--- a/spec/Section 6 -- Execution.md
+++ b/spec/Section 6 -- Execution.md
@@ -693,5 +693,9 @@ handled by the parent field. If the parent field may be {null} then it resolves
 to {null}, otherwise if it is a `Non-Null` type, the field error is further
 propagated to it's parent field.
 
+If a `List` type wraps a `Non-Null` type, and one of the elements of that list
+resolves to {null}, then the entire list must resolve to {null}, and propagate the
+field error up if the list is marked `Non-Null` as well.
+
 If all fields from the root of the request to the source of the error return
 `Non-Null` types, then the {"data"} entry in the response should be {null}.


### PR DESCRIPTION
As it stands, the spec is unclear on what to do when an Non-Null element of a list resolves to null. These changes clarify that the entire list should resolve to null, and to propagate the error upwards