### PR TITLE
Add '@ignoreIfUnknown' to allow forward compatibility for clients

### DIFF
--- a/spec/Section 3 -- Type System.md
+++ b/spec/Section 3 -- Type System.md
@@ -969,7 +969,8 @@ a non-null input type as invalid.
 A GraphQL schema includes a list of the directives the execution
 engine supports.
 
-GraphQL implementations should provide the `@skip` and `@include` directives.
+GraphQL implementations should provide the `@skip`, `@include` and
+`ignoreIfUnknown` directives.
 
 
 ### @skip
@@ -1010,6 +1011,20 @@ field or fragment, it *must* be queried only if the `@skip` condition is false
 must *not* be queried if either the `@skip` condition is true *or* the
 `@include` condition is false.
 
+### @ignoreIfUnknown
+
+The `@ignoreIfUnknown` directive may be provided for fields to safely ignore
+them during validation and execution of the query in case they are not defined.
+
+In this example `experimentalField` will be queried only if Query type defines
+this field. However, this query will always pass validation even if 
+`experimentalField` is not defined inside Query type.
+
+```graphql
+{
+  experimentalField @ignoreIfUnknown
+}
+```
 
 ## Initial types
 


### PR DESCRIPTION
GraphQL is an excellent technology for backward compatibility of APIs. However, sometimes you need to provide forward compatibility for the clients. 

The big example is introspection mechanism of GraphQL itself. Up to this moment, there were two changes in it:
  - `onOperation`, `onFragment` and `onField` fields were deprecated in favor of `locations`
  - new `subscriptionType` field was added

In both cases, backward compatibility was preserved, so old clients can still work with newer GraphQL APIs. However, forward compatibility is broken since you can't use the same introspection query for both old and new servers. For example, GraphiQL solves this by having fallback query without `subscriptionType` field: 
https://github.com/graphql/graphiql/blob/master/src/utility/introspectionQueries.js#L11-L13

This problem is even trickier since GraphQL libraries for many languages (including `graphql-js`) expose standard introspection query. Should this "standard" query incorporate features from the last standard or should it stick to the query supported by the first public release of GraphQL?

To address forward compatibility I propose to add `@ignoreIfUnknown` directive that will silently ignore fields that weren't defined inside appropriate type. Comparing to `skip`/include` it will not only omit value from response but also prevent the query failing during validation.

This issue is not only limited to introspection. I think this feature can solve similar problems for IoT (different firmware versions), distributed systems, etc.