### PR TITLE
RFC: Block String

### DIFF
--- a/spec/Appendix B -- Grammar Summary.md
+++ b/spec/Appendix B -- Grammar Summary.md
@@ -70,20 +70,23 @@ Sign :: one of + -
 
 StringValue ::
   - `"` StringCharacter* `"`
-  - `"""` MultiLineStringCharacter* `"""`
+  - `"""` BlockStringCharacter* `"""`
 
 StringCharacter ::
   - SourceCharacter but not `"` or \ or LineTerminator
   - \u EscapedUnicode
   - \ EscapedCharacter
 
-MultiLineStringCharacter ::
-  - SourceCharacter but not `"""` or `\"""`
-  - `\"""`
-
 EscapedUnicode :: /[0-9A-Fa-f]{4}/
 
 EscapedCharacter :: one of `"` \ `/` b f n r t
+
+BlockStringCharacter ::
+  - SourceCharacter but not `"""` or `\"""`
+  - `\"""`
+
+Note: Block string values are interpretted to exclude blank initial and trailing
+lines and uniform indentation with {BlockStringValue()}.
 
 
 ## Query Document

--- a/spec/Appendix B -- Grammar Summary.md
+++ b/spec/Appendix B -- Grammar Summary.md
@@ -69,13 +69,17 @@ ExponentIndicator :: one of `e` `E`
 Sign :: one of + -
 
 StringValue ::
-  - `""`
-  - `"` StringCharacter+ `"`
+  - `"` StringCharacter* `"`
+  - `"""` MultiLineStringCharacter* `"""`
 
 StringCharacter ::
   - SourceCharacter but not `"` or \ or LineTerminator
   - \u EscapedUnicode
   - \ EscapedCharacter
+
+MultiLineStringCharacter ::
+  - SourceCharacter but not `"""` or `\"""`
+  - `\"""`
 
 EscapedUnicode :: /[0-9A-Fa-f]{4}/
 

--- a/spec/Section 2 -- Language.md
+++ b/spec/Section 2 -- Language.md
@@ -694,13 +694,17 @@ The two keywords `true` and `false` represent the two boolean values.
 ### String Value
 
 StringValue ::
-  - `""`
-  - `"` StringCharacter+ `"`
+  - `"` StringCharacter* `"`
+  - `"""` MultiLineStringCharacter* `"""`
 
 StringCharacter ::
   - SourceCharacter but not `"` or \ or LineTerminator
   - \u EscapedUnicode
   - \ EscapedCharacter
+
+MultiLineStringCharacter ::
+  - SourceCharacter but not `"""` or `\"""`
+  - `\"""`
 
 EscapedUnicode :: /[0-9A-Fa-f]{4}/
 
@@ -714,16 +718,34 @@ Note: Unicode characters are allowed within String value literals, however
 GraphQL source must not contain some ASCII control characters so escape
 sequences must be used to represent these characters.
 
+**Multi-line Strings**
+
+Multi-line strings are sequences of characters wrapped in triple-quotes (`"""`).
+White space, line terminators, and quote and backslash characters may all be
+used unescaped, enabling freeform text. Characters must all be valid
+{SourceCharacter} to ensure printable source text. If non-printable ASCII
+characters need to be used, escape sequences must be used within standard
+double-quote strings.
+
 **Semantics**
 
-StringValue :: `""`
-
-  * Return an empty Unicode character sequence.
-
-StringValue :: `"` StringCharacter+ `"`
+StringValue :: `"` StringCharacter* `"`
 
   * Return the Unicode character sequence of all {StringCharacter}
-    Unicode character values.
+    Unicode character values (which may be empty).
+
+StringValue :: `"""` MultiLineStringCharacter* `"""`
+
+  * Return the Unicode character sequence of all {MultiLineStringCharacter}
+    Unicode character values (which may be empty).
+
+MultiLineStringCharacter :: SourceCharacter but not `"""` or `\"""`
+
+  * Return the character value of {SourceCharacter}.
+
+MultiLineStringCharacter :: `\"""`
+
+  * Return the character sequence `"""`.
 
 StringCharacter :: SourceCharacter but not `"` or \ or LineTerminator
 


### PR DESCRIPTION
This RFC adds a new form of `StringValue`, the multi-line string, similar to that found in Coffeescript, Python, and Scala.

A block string starts and ends with a triple-quote:

```
"""This is a triple-quoted string
and it can contain multiple lines"""
```

Block strings are useful for typing literal bodies of text where new lines should be interpreted literally. In fact, the only escape sequence used is `\"""` and `\` is otherwise allowed unescaped. This is beneficial when writing documentation within strings which may reference the back-slash often:

```
"""
In a block string \n and C:\ are unescaped.
"""
```

The primary value of block strings are to write long-form input directly in query text, in tools like GraphiQL, and as a prerequisite to another pending RFC to allow docstring style documentation in the Schema Definition Language.