### PR TITLE
Update to spec-md@0.5.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ so we will define the "name" field to be a non-nullable String. Using a
 shorthand notation that we will use throughout the spec and documentation,
 we would describe the human type as:
 
-```
+```graphql
 type Human {
   name: String
 }
@@ -66,7 +66,7 @@ objects an ID that can be used to refetch the object. So let's add
 that to our Human type. We'll also add a string for their home
 planet.
 
-```
+```graphql
 type Human {
   id: String
   name: String
@@ -78,14 +78,14 @@ Since we're talking about the Star Wars trilogy, it would be useful
 to describe the episodes in which each character appears. To do so, we'll
 first define an enum, which lists the three episodes in the trilogy:
 
-```
+```graphql
 enum Episode { NEWHOPE, EMPIRE, JEDI }
 ```
 
 Now we want to add a field to `Human` describing what episodes they
 were in. This will return a list of `Episode`s:
 
-```
+```graphql
 type Human {
   id: String
   name: String
@@ -97,7 +97,7 @@ type Human {
 Now, let's introduce another type, `Droid`:
 
 
-```
+```graphql
 type Droid {
   id: String
   name: String
@@ -118,7 +118,7 @@ add the `friends` field, that returns a list of `Character`s.
 
 Our type system so far is:
 
-```
+```graphql
 enum Episode { NEWHOPE, EMPIRE, JEDI }
 
 interface Character {
@@ -162,7 +162,7 @@ perfectly reliable; by leaving these fields as nullable, we allow
 ourselves the flexibility to eventually return null to indicate a backend
 error, while also telling the client that the error occurred.
 
-```
+```graphql
 enum Episode { NEWHOPE, EMPIRE, JEDI }
 
 interface Character {
@@ -196,7 +196,7 @@ queries. The name of this type is `Query` by convention, and it describes
 our public, top-level API. Our `Query` type for this example will look like
 this:
 
-```
+```graphql
 type Query {
   hero(episode: Episode): Character
   human(id: String!): Human
@@ -240,7 +240,7 @@ This test file can be run to exercise the reference implementation.
 
 An example query on the above schema would be:
 
-```
+```graphql
 query HeroNameQuery {
   hero {
     name
@@ -268,7 +268,7 @@ Specifying the `query` keyword and an operation name is only required when a
 GraphQL document defines multiple operations.  We therefore could have written
 the previous query with the query shorthand:
 
-```
+```graphql
 {
   hero {
     name
@@ -280,7 +280,7 @@ Assuming that the backing data for the GraphQL server identified R2-D2 as the
 hero. The response continues to vary based on the request; if we asked for
 R2-D2's ID and friends with this query:
 
-```
+```graphql
 query HeroNameAndFriendsQuery {
   hero {
     id
@@ -324,7 +324,7 @@ about each of those objects. So let's construct a query that asks for R2-D2's
 friends, gets their name and episode appearances, then asks for each of *their*
 friends.
 
-```
+```graphql
 query NestedQuery {
   hero {
     name
@@ -383,7 +383,7 @@ which will give us the nested response
 The `Query` type above defined a way to fetch a human given their
 ID. We can use it by hardcoding the ID in the query:
 
-```
+```graphql
 query FetchLukeQuery {
   human(id: "1000") {
     name
@@ -403,7 +403,7 @@ to get
 
 Alternately, we could have defined the query to have a query parameter:
 
-```
+```graphql
 query FetchSomeIDQuery($someId: String!) {
   human(id: $someId) {
     name
@@ -423,7 +423,7 @@ collisions when fetching the same field with different arguments.
 
 We can do that with field aliases, as demonstrated in this query:
 
-```
+```graphql
 query FetchLukeAliased {
   luke: human(id: "1000") {
     name
@@ -448,7 +448,7 @@ where we did not use the alias.
 This is particularly useful if we want to use the same field twice
 with different arguments, as in the following query:
 
-```
+```graphql
 query FetchLukeAndLeiaAliased {
   luke: human(id: "1000") {
     name
@@ -476,7 +476,7 @@ We aliased the result of the first `human` field to the key
 Now imagine we wanted to ask for Luke and Leia's home planets. We could do so
 with this query:
 
-```
+```graphql
 query DuplicateFields {
   luke: human(id: "1000") {
     name
@@ -493,7 +493,7 @@ but we can already see that this could get unwieldy, since we have to add new
 fields to both parts of the query. Instead, we can extract out the common fields
 into a fragment, and include the fragment in the query, like this:
 
-```
+```graphql
 query UseFragment {
   luke: human(id: "1000") {
     ...HumanFragment
@@ -532,7 +532,7 @@ We defined the type system above, so we know the type of each object
 in the output; the query can ask for that type using the special
 field `__typename`, defined on every object.
 
-```
+```graphql
 query CheckTypeOfR2 {
   hero {
     __typename
@@ -556,7 +556,7 @@ This was particularly useful because `hero` was defined to return a `Character`,
 which is an interface; we might want to know what concrete type was actually
 returned. If we instead asked for the hero of Episode V:
 
-```
+```graphql
 query CheckTypeOfLuke {
   hero(episode: EMPIRE) {
     __typename
@@ -599,7 +599,7 @@ To start, let's take a complex valid query. This is the `NestedQuery` example
 from the above section, but with the duplicated fields factored out into
 a fragment:
 
-```
+```graphql
 query NestedQueryWithFragment {
   hero {
     ...NameAndAppearances
@@ -625,7 +625,7 @@ given type. So as `hero` returns a `Character`, we have to query for a field
 on `Character`. That type does not have a `favoriteSpaceship` field, so this
 query:
 
-```
+```graphql
 # INVALID: favoriteSpaceship does not exist on Character
 query HeroSpaceshipQuery {
   hero {
@@ -641,7 +641,7 @@ or an enum, we need to specify what data we want to get back from the field.
 Hero returns a `Character`, and we've been requesting fields like `name` and
 `appearsIn` on it; if we omit that, the query will not be valid:
 
-```
+```graphql
 # INVALID: hero is not a scalar, so fields are needed
 query HeroNoFieldsQuery {
   hero
@@ -651,7 +651,7 @@ query HeroNoFieldsQuery {
 Similarly, if a field is a scalar, it doesn't make sense to query for
 additional fields on it, and doing so will make the query invalid:
 
-```
+```graphql
 # INVALID: name is a scalar, so fields are not permitted
 query HeroFieldsOnScalarQuery {
   hero {
@@ -667,7 +667,7 @@ in question; when we query for `hero` which returns a `Character`, we
 can only query for fields that exist on `Character`. What happens if we
 want to query for R2-D2s primary function, though?
 
-```
+```graphql
 # INVALID: primaryFunction does not exist on Character
 query DroidFieldOnCharacter {
   hero {
@@ -684,7 +684,7 @@ the fragments we introduced earlier to do this. By setting up a fragment defined
 on `Droid` and including it, we ensure that we only query for `primaryFunction`
 where it is defined.
 
-```
+```graphql
 query DroidFieldInFragment {
   hero {
     name
@@ -703,7 +703,7 @@ Instead of using a named fragment, we can use an inline fragment; this
 still allows us to indicate the type we are querying on, but without naming
 a separate fragment:
 
-```
+```graphql
 query DroidFieldInInlineFragment {
   hero {
     name
@@ -739,7 +739,7 @@ we didn't, we can ask GraphQL, by querying the `__schema` field, always
 available on the root type of a Query. Let's do so now, and ask what types
 are available.
 
-```
+```graphql
 query IntrospectionTypeQuery {
   __schema {
     types {
@@ -816,7 +816,7 @@ Now, let's try and figure out a good place to start exploring what queries are
 available. When we designed our type system, we specified what type all queries
 would start at; let's ask the introspection system about that!
 
-```
+```graphql
 query IntrospectionQueryTypeQuery {
   __schema {
     queryType {
@@ -849,7 +849,7 @@ It is often useful to examine one specific type. Let's take a look at
 the `Droid` type:
 
 
-```
+```graphql
 query IntrospectionDroidTypeQuery {
   __type(name: "Droid") {
     name
@@ -870,7 +870,7 @@ and we get back:
 What if we want to know more about Droid, though? For example, is it
 an interface or an object?
 
-```
+```graphql
 query IntrospectionDroidKindQuery {
   __type(name: "Droid") {
     name
@@ -894,7 +894,7 @@ and we get back:
 we asked about `Character` instead:
 
 
-```
+```graphql
 query IntrospectionCharacterKindQuery {
   __type(name: "Character") {
     name
@@ -919,7 +919,7 @@ We'd find that it is an interface.
 It's useful for an object to know what fields are available, so let's
 ask the introspection system about `Droid`:
 
-```
+```graphql
 query IntrospectionDroidFieldsQuery {
   __type(name: "Droid") {
     name
@@ -992,7 +992,7 @@ Similarly, both `friends` and `appearsIn` have no name, since they are the
 `LIST` wrapper type. We can query for `ofType` on those types, which will
 tell us what these are lists of.
 
-```
+```graphql
 query IntrospectionDroidWrappedFieldsQuery {
   __type(name: "Droid") {
     name
@@ -1075,7 +1075,7 @@ and we get back:
 Let's end with a feature of the introspection system particularly useful
 for tooling; let's ask the system for documentation!
 
-```
+```graphql
 query IntrospectionDroidDescriptionQuery {
   __type(name: "Droid") {
     name

--- a/package.json
+++ b/package.json
@@ -17,10 +17,10 @@
   },
   "scripts": {
     "test": "spec-md spec/GraphQL.md > /dev/null",
-    "build": "mkdir -p out; cp node_modules/spec-md/css/* out; spec-md spec/GraphQL.md > out/index.html",
+    "build": "mkdir -p out; spec-md spec/GraphQL.md > out/index.html",
     "deploy": "npm run build && (cd out && git init && git config user.name \"Travis CI\" && git config user.email \"github@fb.com\" && git add . && git commit -m \"Deploy to GitHub Pages\" && git push --force --quiet \"https://${GH_TOKEN}@github.com/facebook/graphql.git\" master:gh-pages > /dev/null 2>&1)"
   },
   "devDependencies": {
-    "spec-md": "0.4.7"
+    "spec-md": "0.5.1"
   }
 }

--- a/spec/Section 1 -- Overview.md
+++ b/spec/Section 1 -- Overview.md
@@ -7,7 +7,7 @@ requirements and interactions.
 For example, this GraphQL request will receive the name of the user with id 4
 from the Facebook implementation of GraphQL.
 
-```graphql
+```graphql example
 {
   user(id: 4) {
     name
@@ -17,7 +17,7 @@ from the Facebook implementation of GraphQL.
 
 Which produces the resulting data (in JSON):
 
-```js
+```json example
 {
   "user": {
     "name": "Mark Zuckerberg"

--- a/spec/Section 2 -- Language.md
+++ b/spec/Section 2 -- Language.md
@@ -207,7 +207,7 @@ Each operation is represented by an optional operation name and a selection set.
 For example, this mutation operation might "like" a story and then retrieve the
 new number of likes:
 
-```
+```graphql example
 mutation {
   likeStory(storyID: 12345) {
     story {
@@ -225,7 +225,7 @@ short-hand form which omits the query keyword and query name.
 
 For example, this unnamed query operation is written via query shorthand.
 
-```graphql
+```graphql example
 {
   field
 }
@@ -247,7 +247,7 @@ An operation selects the set of information it needs, and will receive exactly
 that information and nothing more, avoiding over-fetching and
 under-fetching data.
 
-```graphql
+```graphql example
 {
   id
   firstName
@@ -275,7 +275,7 @@ shaped response.
 For example, this operation selects fields of complex data and relationships
 down to scalar values.
 
-```graphql
+```graphql example
 {
   me {
     id
@@ -298,7 +298,7 @@ viewer. Some typical examples of these top fields include references to a
 current logged-in viewer, or accessing certain types of data referenced by a
 unique identifier.
 
-```graphql
+```graphql example
 # `me` could represent the currently logged in viewer.
 {
   me {
@@ -329,7 +329,7 @@ function arguments within a GraphQL server's implementation.
 In this example, we want to query a specific user (requested via the `id`
 argument) and their profile picture of a specific `size`:
 
-```graphql
+```graphql example
 {
   user(id: 4) {
     id
@@ -341,7 +341,7 @@ argument) and their profile picture of a specific `size`:
 
 Many arguments can exist for a given field:
 
-```graphql
+```graphql example
 {
   user(id: 4) {
     id
@@ -358,13 +358,13 @@ semantic meaning.
 
 These two queries are semantically identical:
 
-```graphql
+```graphql example
 {
   picture(width: 200, height: 100)
 }
 ```
 
-```graphql
+```graphql example
 {
   picture(height: 100, width: 200)
 }
@@ -381,7 +381,7 @@ queried. However, you can define a different name by specifying an alias.
 In this example, we can fetch two profile pictures of different sizes and ensure
 the resulting object will not have duplicate keys:
 
-```graphql
+```graphql example
 {
   user(id: 4) {
     id
@@ -394,7 +394,7 @@ the resulting object will not have duplicate keys:
 
 Which returns the result:
 
-```js
+```json example
 {
   "user": {
     "id": 4,
@@ -407,7 +407,7 @@ Which returns the result:
 
 Since the top level of a query is a field, it also can be given an alias:
 
-```graphql
+```graphql example
 {
   zuck: user(id: 4) {
     id
@@ -418,7 +418,7 @@ Since the top level of a query is a field, it also can be given an alias:
 
 Returns the result:
 
-```js
+```json example
 {
   "zuck": {
     "id": 4,
@@ -449,7 +449,7 @@ or union.
 For example, if we wanted to fetch some common information about mutual friends
 as well as friends of some user:
 
-```graphql
+```graphql example
 query noFragments {
   user(id: 4) {
     friends(first: 10) {
@@ -469,7 +469,7 @@ query noFragments {
 The repeated fields could be extracted into a fragment and composed by
 a parent fragment or query.
 
-```graphql
+```graphql example
 query withFragments {
   user(id: 4) {
     friends(first: 10) {
@@ -495,7 +495,7 @@ spreads.
 
 For example:
 
-```graphql
+```graphql example
 query withNestedFragments {
   user(id: 4) {
     friends(first: 10) {
@@ -539,7 +539,7 @@ it is operating on matches the type of the fragment.
 
 For example in this query on the Facebook data model:
 
-```graphql
+```graphql example
 query FragmentTyping {
   profiles(handles: ["zuck", "cocacola"]) {
     handle
@@ -566,7 +566,7 @@ The `profiles` root field returns a list where each element could be a `Page` or
 present and `likers` will not. Conversely when the result is a `Page`, `likers`
 will be present and `friends` will not.
 
-```js
+```json example
 {
   "profiles": [
     {
@@ -591,7 +591,7 @@ conditionally include fields based on their runtime type. This feature of
 standard fragment inclusion was demonstrated in the `query FragmentTyping`
 example. We could accomplish the same thing using inline fragments.
 
-```graphql
+```graphql example
 query inlineFragmentTyping {
   profiles(handles: ["zuck", "cocacola"]) {
     handle
@@ -613,7 +613,7 @@ Inline fragments may also be used to apply a directive to a group of fields.
 If the TypeCondition is omitted, an inline fragment is considered to be of the
 same type as the enclosing context.
 
-```graphql
+```graphql example
 query inlineFragmentNoType($expandedInfo: Boolean) {
   user(handle: "zuck") {
     id
@@ -763,7 +763,7 @@ GraphQL has two semantically different ways to represent the lack of a value:
 
 For example, these two field calls are similar, but are not identical:
 
-```graphql
+```graphql example
 {
   field(arg: null)
   field
@@ -838,13 +838,13 @@ identical semantic meaning.
 
 These two queries are semantically identical:
 
-```graphql
+```graphql example
 {
   nearestThing(location: { lon: 12.43, lat: -53.211 })
 }
 ```
 
-```graphql
+```graphql example
 {
   nearestThing(location: { lat: -53.211, lon: 12.43 })
 }
@@ -888,7 +888,7 @@ throughout the execution of that operation.
 In this example, we want to fetch a profile picture size based on the size
 of a particular device:
 
-```graphql
+```graphql example
 query getZuckProfile($devicePicSize: Int) {
   user(id: 4) {
     id
@@ -903,7 +903,7 @@ request so they may be substituted during execution. If providing JSON for the
 variables' values, we could run this query and request profilePic of
 size `60` width:
 
-```js
+```json example
 {
   "devicePicSize": 60
 }

--- a/spec/Section 3 -- Type System.md
+++ b/spec/Section 3 -- Type System.md
@@ -265,7 +265,7 @@ introspection system.
 
 For example, a type `Person` could be described as:
 
-```
+```graphql example
 type Person {
   name: String
   age: Int
@@ -285,7 +285,7 @@ that object.
 
 For example, selecting all the fields of `Person`:
 
-```graphql
+```graphql example
 {
   name
   age
@@ -295,7 +295,7 @@ For example, selecting all the fields of `Person`:
 
 Would yield the object:
 
-```js
+```json example
 {
   "name": "Mark Zuckerberg",
   "age": 30,
@@ -305,7 +305,7 @@ Would yield the object:
 
 While selecting a subset of fields:
 
-```graphql
+```graphql example
 {
   age
   name
@@ -314,7 +314,7 @@ While selecting a subset of fields:
 
 Must only yield exactly that subset:
 
-```js
+```json example
 {
   "age": 30,
   "name": "Mark Zuckerberg"
@@ -327,7 +327,7 @@ underlying base type is one of those five.
 
 For example, the `Person` type might include a `relationship`:
 
-```
+```graphql example
 type Person {
   name: String
   age: Int
@@ -339,7 +339,7 @@ type Person {
 Valid queries must supply a nested field set for a field that returns
 an object, so this query is not valid:
 
-```!graphql
+```graphql counter-example
 {
   name
   relationship
@@ -348,7 +348,7 @@ an object, so this query is not valid:
 
 However, this example is valid:
 
-```graphql
+```graphql example
 {
   name
   relationship {
@@ -359,7 +359,7 @@ However, this example is valid:
 
 And will yield the subset of each object type queried:
 
-```js
+```json example
 {
   "name": "Mark Zuckerberg",
   "relationship": {
@@ -388,7 +388,7 @@ be anticipated.
 If a fragment is spread before other fields, the fields that fragment specifies
 occur in the response before the following fields.
 
-```graphql
+```graphql example
 {
   foo
   ...Frag
@@ -403,7 +403,7 @@ fragment Frag on Query {
 
 Produces the ordered result:
 
-```js
+```json example
 {
   "foo": 1,
   "bar": 2,
@@ -416,7 +416,7 @@ If a field is queried multiple times in a selection, it is ordered by the first
 time it is encountered. However fragments for which the type does not apply does
 not affect ordering.
 
-```graphql
+```graphql example
 {
   foo
   ...Ignored
@@ -438,7 +438,7 @@ fragment Matching on Query {
 
 Produces the ordered result:
 
-```js
+```json example
 {
   "foo": 1,
   "bar": 2,
@@ -449,7 +449,7 @@ Produces the ordered result:
 Also, if directives result in fields being excluded, they are not considered in
 the ordering of fields.
 
-```graphql
+```graphql example
 {
   foo @skip(if: true)
   bar
@@ -459,7 +459,7 @@ the ordering of fields.
 
 Produces the ordered result:
 
-```js
+```json example
 {
   "bar": 1,
   "foo": 2
@@ -490,7 +490,7 @@ introspection system.
 For example, a `Person` type with a `picture` field could accept an argument to
 determine what size of an image to return.
 
-```
+```graphql example
 type Person {
   name: String
   picture(size: Int): Url
@@ -502,7 +502,7 @@ these arguments.
 
 This example query:
 
-```graphql
+```graphql example
 {
   name
   picture(size: 600)
@@ -511,7 +511,7 @@ This example query:
 
 May yield the result:
 
-```js
+```json example
 {
   "name": "Mark Zuckerberg",
   "picture": "http://some.cdn/picture_600.jpg"
@@ -578,7 +578,7 @@ type whose base type is one of those five.
 For example, an interface may describe a required field and types such as
 `Person` or `Business` may then implement this interface.
 
-```
+```graphql example
 interface NamedEntity {
   name: String
 }
@@ -599,7 +599,7 @@ expected, but some fields should be guaranteed.
 
 To continue the example, a `Contact` might refer to `NamedEntity`.
 
-```
+```graphql example
 type Contact {
   entity: NamedEntity
   phoneNumber: String
@@ -610,7 +610,7 @@ type Contact {
 This allows us to write a query for a `Contact` that can select the
 common fields.
 
-```graphql
+```graphql example
 {
   entity {
     name
@@ -624,7 +624,7 @@ the interface may be queried. In the above example, `entity` returns a
 `NamedEntity`, and `name` is defined on `NamedEntity`, so it is valid. However,
 the following would not be a valid query:
 
-```!graphql
+```graphql counter-example
 {
   entity {
     name
@@ -638,7 +638,7 @@ because `entity` refers to a `NamedEntity`, and `age` is not defined on that
 interface. Querying for `age` is only valid when the result of `entity` is a
 `Person`; the query can express this using a fragment or an inline fragment:
 
-```graphql
+```graphql example
 {
   entity {
     name
@@ -687,7 +687,7 @@ typed fragments.
 
 For example, we might have the following type system:
 
-```
+```graphql example
 union SearchResult = Photo | Person
 
 type Person {
@@ -711,7 +711,7 @@ type. If the query wanted the name if the result was a Person, and the height if
 it was a photo, the following query is invalid, because the union itself
 defines no fields:
 
-```!graphql
+```graphql counter-example
 {
   firstSearchResult {
     name
@@ -722,7 +722,7 @@ defines no fields:
 
 Instead, the query would be:
 
-```graphql
+```graphql example
 {
   firstSearchResult {
     ... on Person {
@@ -827,7 +827,7 @@ type declared by the input field.
 
 Following are examples of Input Object coercion for the type:
 
-```graphql
+```graphql example
 input ExampleInputObject {
   a: String
   b: Int!
@@ -934,7 +934,7 @@ other than {null}, or a Non-Null variable value, it is coerced using the input c
 
 Example: A non-null argument cannot be omitted.
 
-```!graphql
+```graphql counter-example
 {
   fieldWithNonNullArg
 }
@@ -942,7 +942,7 @@ Example: A non-null argument cannot be omitted.
 
 Example: The value {null} cannot be provided to a non-null argument.
 
-```!graphql
+```graphql counter-example
 {
   fieldWithNonNullArg(nonNullArg: null)
 }
@@ -950,7 +950,7 @@ Example: The value {null} cannot be provided to a non-null argument.
 
 Example: A variable of a nullable type cannot be provided to a non-null argument.
 
-```graphql
+```graphql example
 query withNullableVariable($var: String) {
   fieldWithNonNullArg(nonNullArg: $var)
 }
@@ -978,10 +978,10 @@ The `@skip` directive may be provided for fields, fragment spreads, and
 inline fragments, and allows for conditional exclusion during execution as
 described by the if argument.
 
-In this example `experimentalField` will only be queried if the variable 
+In this example `experimentalField` will only be queried if the variable
 `$someTest` has the value `false`.
 
-```graphql
+```graphql example
 query myQuery($someTest: Boolean) {
   experimentalField @skip(if: $someTest)
 }
@@ -994,10 +994,10 @@ The `@include` directive may be provided for fields, fragment spreads, and
 inline fragments, and allows for conditional inclusion during execution as
 described by the if argument.
 
-In this example `experimentalField` will only be queried if the variable 
+In this example `experimentalField` will only be queried if the variable
 `$someTest` has the value `true`
 
-```graphql
+```graphql example
 query myQuery($someTest: Boolean) {
   experimentalField @include(if: $someTest)
 }
@@ -1026,7 +1026,7 @@ The fields on the query type indicate what fields are available at
 the top level of a GraphQL query. For example, a basic GraphQL query
 like this one:
 
-```graphql
+```graphql example
 query getMe {
   me
 }
@@ -1035,7 +1035,7 @@ query getMe {
 Is valid when the type provided for the query starting type has a field
 named "me". Similarly
 
-```graphql
+```graphql example
 mutation setName {
   setName(name: "Zuck") {
     newName
@@ -1046,7 +1046,7 @@ mutation setName {
 Is valid when the type provided for the mutation starting type is not null,
 and has a field named "setName" with a string argument named "name".
 
-```graphql
+```graphql example
 subscription {
   newMessage {
     text
@@ -1055,4 +1055,4 @@ subscription {
 ```
 
 Is valid when the type provided for the subscription starting type is not null,
-and has a field named "newMessage" and only contains a single root field. 
+and has a field named "newMessage" and only contains a single root field.

--- a/spec/Section 4 -- Introspection.md
+++ b/spec/Section 4 -- Introspection.md
@@ -8,7 +8,7 @@ three fields: id, name, and birthday.
 
 For example, given a server with the following type definition:
 
-```
+```graphql example
 type User {
   id: String
   name: String
@@ -18,7 +18,7 @@ type User {
 
 The query
 
-```graphql
+```graphql example
 {
   __type(name: "User") {
     name
@@ -34,7 +34,7 @@ The query
 
 would return
 
-```js
+```json example
 {
   "__type": {
     "name": "User",
@@ -109,7 +109,7 @@ The schema introspection system is accessible from the meta-fields `__schema`
 and `__type` which are accessible from the type of the root of a query
 operation.
 
-```
+```graphql
 __schema: __Schema!
 __type(name: String!): __Type
 ```
@@ -119,7 +119,7 @@ of the query operation.
 
 The schema of the GraphQL schema introspection system:
 
-```
+```graphql
 type __Schema {
   types: [__Type!]!
   queryType: __Type!
@@ -312,7 +312,7 @@ of named input values.
 
 For example the input object `Point` could be defined as:
 
-```
+```graphql example
 input Point {
   x: Int
   y: Int

--- a/spec/Section 5 -- Validation.md
+++ b/spec/Section 5 -- Validation.md
@@ -35,7 +35,7 @@ be free of any validation errors, and have not changed since.
 For this section of this schema, we will assume the following type system
 in order to demonstrate examples:
 
-```
+```graphql example
 enum DogCommand { SIT, DOWN, HEEL }
 
 type Dog implements Pet {
@@ -104,7 +104,7 @@ to by its name.
 
 For example the following document is valid:
 
-```graphql
+```graphql example
 query getDogName {
   dog {
     name
@@ -122,7 +122,7 @@ query getOwnerName {
 
 While this document is invalid:
 
-```!graphql
+```graphql counter-example
 query getName {
   dog {
     name
@@ -140,7 +140,7 @@ query getName {
 
 It is invalid even if the type of each operation is different:
 
-```!graphql
+```graphql counter-example
 query dogOperation {
   dog {
     name
@@ -172,7 +172,7 @@ one operation exists in the document.
 
 For example the following document is valid:
 
-```graphql
+```graphql example
 {
   dog {
     name
@@ -182,7 +182,7 @@ For example the following document is valid:
 
 While this document is invalid:
 
-```!graphql
+```graphql counter-example
 {
   dog {
     name
@@ -214,7 +214,7 @@ Subscription operations must have exactly one root field.
 
 Valid examples:
 
-```graphql
+```graphql example
 subscription sub {
   newMessage {
     body
@@ -223,7 +223,7 @@ subscription sub {
 }
 ```
 
-```graphql
+```graphql example
 fragment newMessageFields on Message {
   body
   sender
@@ -231,14 +231,14 @@ fragment newMessageFields on Message {
 
 subscription sub {
   newMessage {
-    ... newMessageFields  
+    ... newMessageFields
   }
 }
 ```
 
 Invalid:
 
-```!graphql
+```graphql counter-example
 subscription sub {
   newMessage {
     body
@@ -250,7 +250,7 @@ subscription sub {
 
 Introspection fields are counted. The following example is also invalid:
 
-```!graphql
+```graphql counter-example
 subscription sub {
   newMessage {
     body
@@ -277,7 +277,7 @@ selection set. There are no limitations on alias names.
 
 For example the following fragment would not pass validation:
 
-```!graphql
+```graphql counter-example
 fragment fieldNotDefined on Dog {
   meowVolume
 }
@@ -293,7 +293,7 @@ interface-typed selection set.
 
 For example, the following is valid:
 
-```graphql
+```graphql example
 fragment interfaceFieldSelection on Pet {
   name
 }
@@ -301,7 +301,7 @@ fragment interfaceFieldSelection on Pet {
 
 and the following is invalid:
 
-```!graphql
+```graphql counter-example
 fragment definedOnImplementorsButNotInterface on Pet {
   nickname
 }
@@ -314,7 +314,7 @@ a fragment.
 
 For example the following is valid:
 
-```graphql
+```graphql example
 fragment inDirectFieldSelectionOnUnion on CatOrDog {
   __typename
   ... on Pet {
@@ -328,7 +328,7 @@ fragment inDirectFieldSelectionOnUnion on CatOrDog {
 
 But the following is invalid:
 
-```!graphql
+```graphql counter-example
 fragment directFieldSelectionOnUnion on CatOrDog {
   name
   barkVolume
@@ -390,7 +390,7 @@ however nested fragments can make this difficult to detect manually.
 
 The following selections correctly merge:
 
-```graphql
+```graphql example
 fragment mergeIdenticalFields on Dog {
   name
   name
@@ -404,7 +404,7 @@ fragment mergeIdenticalAliasesAndFields on Dog {
 
 The following is not able to merge:
 
-```!graphql
+```graphql counter-example
 fragment conflictingBecauseAlias on Dog {
   name: nickname
   name
@@ -416,7 +416,7 @@ values and variables can be correctly merged.
 
 For example the following correctly merge:
 
-```graphql
+```graphql example
 fragment mergeIdenticalFieldsWithIdenticalArgs on Dog {
   doesKnowCommand(dogCommand: SIT)
   doesKnowCommand(dogCommand: SIT)
@@ -430,7 +430,7 @@ fragment mergeIdenticalFieldsWithIdenticalValues on Dog {
 
 The following do not correctly merge:
 
-```!graphql
+```graphql counter-example
 fragment conflictingArgsOnValues on Dog {
   doesKnowCommand(dogCommand: SIT)
   doesKnowCommand(dogCommand: HEEL)
@@ -455,7 +455,7 @@ fragment differingArgs on Dog {
 The following fields would not merge together, however both cannot be
 encountered against the same object, so they are safe:
 
-```graphql
+```graphql example
 fragment safeDifferingFields on Pet {
   ... on Dog {
     volume: barkVolume
@@ -479,7 +479,7 @@ However, the field responses must be shapes which can be merged. For example,
 scalar values must not differ. In this example, `someValue` might be a `String`
 or an `Int`:
 
-```!graphql
+```graphql counter-example
 fragment conflictingDifferingResponses on Pet {
   ... on Dog {
     someValue: nickname
@@ -509,7 +509,7 @@ are the leaf nodes of any GraphQL query.
 
 The following is valid.
 
-```graphql
+```graphql example
 fragment scalarSelection on Dog {
   barkVolume
 }
@@ -517,7 +517,7 @@ fragment scalarSelection on Dog {
 
 The following is invalid.
 
-```!graphql
+```graphql counter-example
 fragment scalarSelectionsNotAllowedOnBoolean on Dog {
   barkVolume {
     sinceWhen
@@ -531,7 +531,7 @@ and unions without subfields are disallowed.
 
 Let's assume the following additions to the query root type of the schema:
 
-```
+```graphql example
 extend type QueryRoot {
   human: Human
   pet: Pet
@@ -541,7 +541,7 @@ extend type QueryRoot {
 
 The following examples are invalid
 
-```!graphql
+```graphql counter-example
 query directQueryOnObjectWithoutSubFields {
   human
 }
@@ -578,7 +578,7 @@ possible arguments of that field or directive.
 
 For example the following are valid:
 
-```graphql
+```graphql example
 fragment argOnRequiredArg on Dog {
   doesKnowCommand(dogCommand: SIT)
 }
@@ -590,7 +590,7 @@ fragment argOnOptional on Dog {
 
 the following is invalid since `command` is not defined on `DogCommand`.
 
-```!graphql
+```graphql counter-example
 fragment invalidArgName on Dog {
   doesKnowCommand(command: CLEAN_UP_HOUSE)
 }
@@ -598,7 +598,7 @@ fragment invalidArgName on Dog {
 
 and this is also invalid as `unless` is not defined on `@include`.
 
-```!graphql
+```graphql counter-example
 fragment invalidArgName on Dog {
   isHousetrained(atOtherHomes: true) @include(unless: false)
 }
@@ -607,7 +607,7 @@ fragment invalidArgName on Dog {
 In order to explore more complicated argument examples, let's add the following
 to our type system:
 
-```
+```graphql example
 type Arguments {
   multipleReqs(x: Int!, y: Int!): Int!
   booleanArgField(booleanArg: Boolean): Boolean
@@ -624,7 +624,7 @@ extend type QueryRoot {
 
 Order does not matter in arguments. Therefore both the following example are valid.
 
-```graphql
+```graphql example
 fragment multipleArgs on Arguments {
   multipleReqs(x: 1, y: 2)
 }
@@ -670,7 +670,7 @@ being provided to, as per the coercion rules defined in the Type System chapter.
 
 For example, an Int can be coerced into a Float.
 
-```graphql
+```graphql example
 fragment goodBooleanArg on Arguments {
   booleanArgField(booleanArg: true)
 }
@@ -683,7 +683,7 @@ fragment coercedIntIntoFloatArg on Arguments {
 An incoercible conversion, is string to int. Therefore, the
 following example is invalid.
 
-```!graphql
+```graphql counter-example
 fragment stringIntoInt on Arguments {
   intArgField(intArg: "3")
 }
@@ -712,7 +712,7 @@ Otherwise, the argument is optional.
 
 For example the following are valid:
 
-```graphql
+```graphql example
 fragment goodBooleanArg on Arguments {
   booleanArgField(booleanArg: true)
 }
@@ -726,7 +726,7 @@ The argument can be omitted from a field with a nullable argument.
 
 Therefore the following query is valid:
 
-```graphql
+```graphql example
 fragment goodBooleanArgDefault on Arguments {
   booleanArgField
 }
@@ -734,7 +734,7 @@ fragment goodBooleanArgDefault on Arguments {
 
 but this is not valid on a non-null argument.
 
-```!graphql
+```graphql counter-example
 fragment missingRequiredArg on Arguments {
   nonNullBooleanArgField
 }
@@ -742,7 +742,7 @@ fragment missingRequiredArg on Arguments {
 
 Providing the explicit value {null} is also not valid.
 
-```!graphql
+```graphql counter-example
 fragment missingRequiredArg on Arguments {
   notNullBooleanArgField(nonNullBooleanArg: null)
 }
@@ -771,7 +771,7 @@ validation rule.
 
 For example the following document is valid:
 
-```graphql
+```graphql example
 {
   dog {
     ...fragmentOne
@@ -792,7 +792,7 @@ fragment fragmentTwo on Dog {
 
 While this document is invalid:
 
-```!graphql
+```graphql counter-example
 {
   dog {
     ...fragmentOne
@@ -827,7 +827,7 @@ not defined in the schema, the query does not validate.
 
 For example the following fragments are valid:
 
-```graphql
+```graphql example
 fragment correctType on Dog {
   name
 }
@@ -847,7 +847,7 @@ fragment inlineFragment2 on Dog {
 
 and the following do not validate:
 
-```!graphql
+```graphql counter-example
 fragment notOnExistingType on NotInSchema {
   name
 }
@@ -876,7 +876,7 @@ applies to both inline and named fragments.
 
 The following fragment declarations are valid:
 
-```graphql
+```graphql example
 fragment fragOnObject on Dog {
   name
 }
@@ -894,7 +894,7 @@ fragment fragOnUnion on CatOrDog {
 
 and the following are invalid:
 
-```!graphql
+```graphql counter-example
 fragment fragOnScalar on Int {
   something
 }
@@ -920,7 +920,7 @@ Defined fragments must be used within a query document.
 
 For example the following is an invalid query document:
 
-```!graphql
+```graphql counter-example
 fragment nameFragment on Dog { # unused
   name
 }
@@ -955,7 +955,7 @@ Named fragment spreads must refer to fragments defined
 within the document.  If the target of a spread is
 not defined, this is an error:
 
-```!graphql
+```graphql counter-example
 {
   dog {
     ...undefinedFragment
@@ -988,7 +988,7 @@ in the underlying data.
 
 This invalidates fragments that would result in an infinite spread:
 
-```!graphql
+```graphql counter-example
 {
   dog {
     ...nameFragment
@@ -1008,7 +1008,7 @@ fragment barkVolumeFragment on Dog {
 
 If the above fragments were inlined, this would result in the infinitely large:
 
-```graphql
+```graphql example
 {
   dog {
     name
@@ -1026,7 +1026,7 @@ If the above fragments were inlined, this would result in the infinitely large:
 This also invalidates fragments that would result in an infinite recursion when
 executed against cyclic data:
 
-```!graphql
+```graphql counter-example
 {
   dog {
     ...dogFragment
@@ -1083,7 +1083,7 @@ is in scope.
 
 For example
 
-```graphql
+```graphql example
 fragment dogFragment on Dog {
   ... on Dog {
     barkVolume
@@ -1093,7 +1093,7 @@ fragment dogFragment on Dog {
 
 and the following is invalid
 
-```!graphql
+```graphql counter-example
 fragment catInDogFragmentInvalid on Dog {
   ... on Cat {
     meowVolume
@@ -1109,7 +1109,7 @@ if the object type implements the interface or is a member of the union.
 
 For example
 
-```graphql
+```graphql example
 fragment petNameFragment on Pet {
   name
 }
@@ -1123,7 +1123,7 @@ is valid because {Dog} implements Pet.
 
 Likewise
 
-```graphql
+```graphql example
 fragment catOrDogNameFragment on CatOrDog {
   ... on Cat {
     meowVolume
@@ -1150,7 +1150,7 @@ that interface or union.
 
 For example, the following fragments are valid:
 
-```graphql
+```graphql example
 fragment petFragment on Pet {
   name
   ... on Dog {
@@ -1171,7 +1171,7 @@ fragment catOrDogFragment on CatOrDog {
 
 By contrast the following fragments are invalid:
 
-```!graphql
+```graphql counter-example
 fragment sentientFragment on Sentient {
   ... on Dog {
     barkVolume
@@ -1199,7 +1199,7 @@ possible types of the scope and the spread, the spread is considered valid.
 
 So for example
 
-```graphql
+```graphql example
 fragment unionWithInterface on Pet {
   ...dogOrHumanFragment
 }
@@ -1216,7 +1216,7 @@ member of {DogOrHuman}.
 
 However
 
-```!graphql
+```graphql counter-example
 fragment nonIntersectingInterfaces on Pet {
   ...sentientFragment
 }
@@ -1250,7 +1250,7 @@ an ambiguity would exist which includes an ignored portion of syntax.
 
 For example the following query will not pass validation.
 
-```!graphql
+```graphql counter-example
 {
   field(arg: { field: true, field: false })
 }
@@ -1295,7 +1295,7 @@ server has declared support for.
 For example the following query will not pass validation because `@skip` does
 not provide `QUERY` as a valid location.
 
-```!graphql
+```graphql counter-example
 query @skip(if: $foo) {
   field
 }
@@ -1324,7 +1324,7 @@ directive is allowed per location.
 For example, the following query will not pass validation because `@skip` has
 been used twice for the same field:
 
-```!graphql
+```graphql counter-example
 query ($foo: Boolean = true, $bar: Boolean = false) {
   field @skip(if: $foo) @skip(if: $bar)
 }
@@ -1333,7 +1333,7 @@ query ($foo: Boolean = true, $bar: Boolean = false) {
 However the following example is valid because `@skip` has been used only once
 per location, despite being used twice in the query and on the same named field:
 
-```graphql
+```graphql example
 query ($foo: Boolean = true, $bar: Boolean = false) {
   field @skip(if: $foo) {
     subfieldA
@@ -1364,7 +1364,7 @@ If any operation defines more than one variable with the same name, it is
 ambiguous and invalid. It is invalid even if the type of the duplicate variable
 is the same.
 
-```!graphql
+```graphql counter-example
 query houseTrainedQuery($atOtherHomes: Boolean, $atOtherHomes: Boolean) {
   dog {
     isHousetrained(atOtherHomes: $atOtherHomes)
@@ -1376,7 +1376,7 @@ query houseTrainedQuery($atOtherHomes: Boolean, $atOtherHomes: Boolean) {
 It is valid for multiple operations to define a variable with the same name. If
 two operations reference the same fragment, it might actually be necessary:
 
-```graphql
+```graphql example
 query A($atOtherHomes: Boolean) {
   ...HouseTrainedFragment
 }
@@ -1411,7 +1411,7 @@ if the type of that variable is not non-null.
 
 For example the following query will pass validation.
 
-```graphql
+```graphql example
 query houseTrainedQuery($atOtherHomes: Boolean = true) {
   dog {
     isHousetrained(atOtherHomes: $atOtherHomes)
@@ -1423,7 +1423,7 @@ However if the variable is defined as non-null, default values
 are unreachable. Therefore queries such as the following fail
 validation
 
-```!graphql
+```graphql counter-example
 query houseTrainedQuery($atOtherHomes: Boolean! = true) {
   dog {
     isHousetrained(atOtherHomes: $atOtherHomes)
@@ -1436,7 +1436,7 @@ Types must match or they must be coercible to the type.
 
 Non-matching types fail, such as in the following example:
 
-```!graphql
+```graphql counter-example
 query houseTrainedQuery($atOtherHomes: Boolean = "true") {
   dog {
     isHousetrained(atOtherHomes: $atOtherHomes)
@@ -1448,7 +1448,7 @@ However if a type is coercible the query will pass validation.
 
 For example:
 
-```graphql
+```graphql example
 query intToFloatQuery($floatVar: Float = 1) {
   arguments {
     floatArgField(floatArg: $floatVar)
@@ -1476,7 +1476,7 @@ and interfaces cannot be used as inputs.
 
 For these examples, consider the following typesystem additions:
 
-```
+```graphql example
 input ComplexInput { name: String, owner: String }
 
 extend type QueryRoot {
@@ -1487,7 +1487,7 @@ extend type QueryRoot {
 
 The following queries are valid:
 
-```graphql
+```graphql example
 query takesBoolean($atOtherHomes: Boolean) {
   dog {
     isHousetrained(atOtherHomes: $atOtherHomes)
@@ -1507,7 +1507,7 @@ query TakesListOfBooleanBang($booleans: [Boolean!]) {
 
 The following queries are invalid:
 
-```!graphql
+```graphql counter-example
 query takesCat($cat: Cat) {
   # ...
 }
@@ -1545,7 +1545,7 @@ operation
 
 For example:
 
-```graphql
+```graphql example
 query variableIsDefined($atOtherHomes: Boolean) {
   dog {
     isHousetrained(atOtherHomes: $atOtherHomes)
@@ -1557,7 +1557,7 @@ is valid. ${atOtherHomes} is defined by the operation.
 
 By contrast the following query is invalid:
 
-```!graphql
+```graphql counter-example
 query variableIsNotDefined {
   dog {
     isHousetrained(atOtherHomes: $atOtherHomes)
@@ -1574,7 +1574,7 @@ must correspond to variable definitions in all of those operations.
 
 For example the following is valid:
 
-```graphql
+```graphql example
 query variableIsDefinedUsedInSingleFragment($atOtherHomes: Boolean) {
   dog {
     ...isHousetrainedFragment
@@ -1593,7 +1593,7 @@ operation.
 On the other hand, if a fragment is included within an operation that does
 not define a referenced variable, the query is invalid.
 
-```!graphql
+```graphql counter-example
 query variableIsNotDefinedUsedInSingleFragment {
   dog {
     ...isHousetrainedFragment
@@ -1607,7 +1607,7 @@ fragment isHousetrainedFragment on Dog {
 
 This applies transitively as well, so the following also fails:
 
-```!graphql
+```graphql counter-example
 query variableIsNotDefinedUsedInNestedFragment {
   dog {
     ...outerHousetrainedFragment
@@ -1626,7 +1626,7 @@ fragment isHousetrainedFragment on Dog {
 Variables must be defined in all operations in which a fragment
 is used.
 
-```graphql
+```graphql example
 query housetrainedQueryOne($atOtherHomes: Boolean) {
   dog {
     ...isHousetrainedFragment
@@ -1646,7 +1646,7 @@ fragment isHousetrainedFragment on Dog {
 
 However the following does not validate:
 
-```!graphql
+```graphql counter-example
 query housetrainedQueryOne($atOtherHomes: Boolean) {
   dog {
     ...isHousetrainedFragment
@@ -1687,7 +1687,7 @@ a validation error.
 
 For example the following is invalid:
 
-```!graphql
+```graphql counter-example
 query variableUnused($atOtherHomes: Boolean) {
   dog {
     isHousetrained
@@ -1699,7 +1699,7 @@ because ${atOtherHomes} is not referenced.
 
 These rules apply to transitive fragment spreads as well:
 
-```graphql
+```graphql example
 query variableUsedInFragment($atOtherHomes: Boolean) {
   dog {
     ...isHousetrainedFragment
@@ -1716,7 +1716,7 @@ which is included by {variableUsedInFragment}.
 
 If that fragment did not have a reference to ${atOtherHomes} it would be not valid:
 
-```!graphql
+```graphql counter-example
 query variableNotUsedWithinFragment($atOtherHomes: Boolean) {
   ...isHousetrainedWithoutVariableFragment
 }
@@ -1730,7 +1730,7 @@ All operations in a document must use all of their variables.
 
 As a result, the following document does not validate.
 
-```!graphql
+```graphql counter-example
 query queryWithUsedVar($atOtherHomes: Boolean) {
   dog {
     ...isHousetrainedFragment
@@ -1781,7 +1781,7 @@ a non-null argument type.
 
 Types must match:
 
-```!graphql
+```graphql counter-example
 query intCannotGoIntoBoolean($intArg: Int) {
   arguments {
     booleanArgField(booleanArg: $intArg)
@@ -1794,7 +1794,7 @@ ${intArg} typed as {Int} cannot be used as a argument to {booleanArg}, typed as 
 List cardinality must also be the same. For example, lists cannot be passed into singular
 values.
 
-```!graphql
+```graphql counter-example
 query booleanListCannotGoIntoBoolean($booleanListArg: [Boolean]) {
   arguments {
     booleanArgField(booleanArg: $booleanListArg)
@@ -1805,7 +1805,7 @@ query booleanListCannotGoIntoBoolean($booleanListArg: [Boolean]) {
 Nullability must also be respected. In general a nullable variable cannot
 be passed to a non-null argument.
 
-```!graphql
+```graphql counter-example
 query booleanArgQuery($booleanArg: Boolean) {
   arguments {
     nonNullBooleanArgField(nonNullBooleanArg: $booleanArg)
@@ -1816,7 +1816,7 @@ query booleanArgQuery($booleanArg: Boolean) {
 A notable exception is when default arguments are provided. They are, in effect,
 treated as non-nulls.
 
-```graphql
+```graphql example
 query booleanArgQueryWithDefault($booleanArg: Boolean = true) {
   arguments {
     nonNullBooleanArgField(nonNullBooleanArg: $booleanArg)
@@ -1829,7 +1829,7 @@ and inner types. A nullable list cannot be passed to a non-null list, and a list
 of nullable values cannot be passed to a list of non-null values.
 The following is valid:
 
-```graphql
+```graphql example
 query nonNullListToList($nonNullBooleanList: [Boolean]!) {
   arguments {
     booleanListArgField(booleanListArg: $nonNullBooleanList)
@@ -1839,7 +1839,7 @@ query nonNullListToList($nonNullBooleanList: [Boolean]!) {
 
 However, a nullable list cannot be passed to a non-null list:
 
-```!graphql
+```graphql counter-example
 query listToNonNullList($booleanList: [Boolean]) {
   arguments {
     nonNullBooleanListField(nonNullBooleanListArg: $booleanList)

--- a/spec/Section 6 -- Execution.md
+++ b/spec/Section 6 -- Execution.md
@@ -172,7 +172,7 @@ Subscriptions at Scale.
 As an example, consider a chat application. To subscribe to new messages posted
 to the chat room, the client sends a request like so:
 
-```graphql
+```graphql example
 subscription NewMessages {
   newMessage(roomId: 123) {
     sender
@@ -185,7 +185,7 @@ While the client is subscribed, whenever new messages are posted to chat room
 with ID "123", the selection for "sender" and "text" will be evaluated and
 published to the client, for example:
 
-```js
+```json example
 {
   "data": {
     "newMessage": {
@@ -327,7 +327,7 @@ freedom to execute the field entries in whatever order it deems optimal.
 
 For example, given the following grouped field set to be executed normally:
 
-```graphql
+```graphql example
 {
   birthday {
     month
@@ -352,7 +352,7 @@ before it continues on to the next item in the grouped field set:
 
 For example, given the following selection set to be executed serially:
 
-```graphql
+```graphql example
 {
   changeBirthday(birthday: $newBirthday) {
     month
@@ -374,7 +374,7 @@ As an illustrative example, let's assume we have a mutation field
 `changeTheNumber` that returns an object containing one field,
 `theNumber`. If we execute the following selection set serially:
 
-```graphql
+```graphql example
 {
   first: changeTheNumber(newNumber: 1) {
     theNumber
@@ -399,7 +399,7 @@ The executor will execute the following serially:
 
 A correct executor must generate the following result for that selection set:
 
-```js
+```json example
 {
   "first": {
     "theNumber": 1
@@ -425,7 +425,7 @@ same time.
 As an example, collecting the fields of this selection set would collect two
 instances of the field `a` and one of field `b`:
 
-```graphql
+```graphql example
 {
   a {
     subfield1
@@ -649,7 +649,7 @@ continue execution of the sub-selection sets.
 An example query illustrating parallel fields with the same name with
 sub-selections.
 
-```graphql
+```graphql example
 {
   me {
     firstName
@@ -694,8 +694,8 @@ to {null}, otherwise if it is a `Non-Null` type, the field error is further
 propagated to it's parent field.
 
 If a `List` type wraps a `Non-Null` type, and one of the elements of that list
-resolves to {null}, then the entire list must resolve to {null}. 
-If the `List` type is also wrapped in a `Non-Null`, the field error continues 
+resolves to {null}, then the entire list must resolve to {null}.
+If the `List` type is also wrapped in a `Non-Null`, the field error continues
 to propagate upwards.
 
 If all fields from the root of the request to the source of the error return

--- a/spec/Section 7 -- Response.md
+++ b/spec/Section 7 -- Response.md
@@ -129,9 +129,9 @@ If the `data` entry in the response is not present, the `errors`
 entry in the response must not be empty. It must contain at least one error.
 The errors it contains should indicate why no data was able to be returned.
 
-If the `data` entry in the response is present (including if it is the value 
-{null}), the `errors` entry in the response may contain any errors that 
-occurred during execution. If errors occurred during execution, it should 
+If the `data` entry in the response is present (including if it is the value
+{null}), the `errors` entry in the response may contain any errors that
+occurred during execution. If errors occurred during execution, it should
 contain those errors.
 
 **Error result format**
@@ -161,7 +161,7 @@ it represents a path in the response, not in the query.
 For example, if fetching one of the friends' names fails in the following
 query:
 
-```graphql
+```graphql example
 {
   hero(episode: $episode) {
     name
@@ -175,7 +175,7 @@ query:
 
 The response might look like:
 
-```js
+```json example
 {
   "errors": [
     {
@@ -215,7 +215,7 @@ For example, if the `name` field from above had declared a `Non-Null` return
 type in the schema, the result would look different but the error reported would
 be the same:
 
-```js
+```json example
 {
   "errors": [
     {


### PR DESCRIPTION
Also takes a pass over the spec, explicitly annotating examples and counter-examples.

While I was at it, I corrected some code language annotations in the README