### PR TITLE
Publish stable permalinks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,8 @@
 *~
 .*.haste_cache.*
 .DS_Store
-build
-out
-node_modules
 npm-debug.log
+/build
+/out
+/gh-pages
+/node_modules

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ node_js: 6
 deploy:
   provider: script
   skip_cleanup: true
-  script: npm run deploy
+  script: ./publish.sh
   on:
     branch: master
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,19 @@
 # GraphQL
 
+The GraphQL specification is edited in the markdown files found in [`/spec`](./spec)
+the latest release of which is published at http://facebook.github.io/graphql/.
+
+The latest draft specification can be found at http://facebook.github.io/graphql/draft/
+which tracks the latest commit to the master branch in this repository.
+
+Previous releases of the GraphQL specification can be found at permalinks that
+match their [release tag](https://github.com/facebook/graphql/releases). For
+example, https://github.com/facebook/graphql/October2016. If you are linking
+directly to the GraphQL specification, it's best to link to a tagged permalink
+for the particular referenced version.
+
+## Overview
+
 This is a Working Draft of the Specification for GraphQL, a query language for APIs created by Facebook.
 
 The target audience for this specification is not the client developer, but those who have,

--- a/package.json
+++ b/package.json
@@ -17,8 +17,7 @@
   },
   "scripts": {
     "test": "spec-md spec/GraphQL.md > /dev/null",
-    "build": "mkdir -p out; spec-md spec/GraphQL.md > out/index.html",
-    "deploy": "npm run build && (cd out && git init && git config user.name \"Travis CI\" && git config user.email \"github@fb.com\" && git add . && git commit -m \"Deploy to GitHub Pages\" && git push --force --quiet \"https://${GH_TOKEN}@github.com/facebook/graphql.git\" master:gh-pages > /dev/null 2>&1)"
+    "build": "mkdir -p out; spec-md spec/GraphQL.md > out/index.html"
   },
   "devDependencies": {
     "spec-md": "0.5.1"

--- a/publish.sh
+++ b/publish.sh
@@ -39,8 +39,8 @@ fi
 echo "Pushing update"
 git config user.name "Travis CI"
 git config user.email "github@fb.com"
-git add .
-git commit -m "Deploy to GitHub Pages"
+git add -A .
+git commit -a -m "Deploy to GitHub Pages"
 git push > /dev/null 2>&1
 
 echo "Pushed"

--- a/publish.sh
+++ b/publish.sh
@@ -1,0 +1,45 @@
+#!/bin/bash -e
+# This script publishes the GraphQL specification document to the web.
+
+# Build the specification document into publishable form
+echo "Building spec"
+npm run build > /dev/null 2>&1
+
+# Check out gh-pages locally.
+echo "Cloning gh-pages"
+rm -rf gh-pages
+git clone -b gh-pages "https://${GH_TOKEN}@github.com/facebook/graphql.git" gh-pages > /dev/null 2>&1
+pushd gh-pages > /dev/null 2>&1
+
+# Replace /draft with this build.
+echo "Publishing to: /draft"
+rm -rf draft
+cp -r ../out draft
+
+# If this is a tagged commit, publish to a permalink and index.
+GITTAG=$(git tag --points-at HEAD)
+if [ -n "$GITTAG" ]; then
+  echo "Publishing to: /$GITTAG"
+  cp -r ../out "$GITTAG"
+
+  echo "Linking from: / (index)"
+  echo '<html>
+  <head>
+    <meta http-equiv="refresh" content="0; url=./'"$GITTAG"'" />
+    <title>GraphQL Specification</title>
+  </head>
+  <body>
+    Redirecting to the latest release: <a href="./'"$GITTAG"'">'"$GITTAG"'</a>
+  </body>
+</html>' > index.html
+fi
+
+echo "Pushing update"
+git config user.name "Travis CI"
+git config user.email "github@fb.com"
+git add .
+git commit -m "Deploy to GitHub Pages"
+git push > /dev/null 2>&1
+
+echo "Pushed"
+popd > /dev/null 2>&1

--- a/publish.sh
+++ b/publish.sh
@@ -5,6 +5,9 @@
 echo "Building spec"
 npm run build > /dev/null 2>&1
 
+# Determine if this is a tagged release
+GITTAG=$(git tag --points-at HEAD)
+
 # Check out gh-pages locally.
 echo "Cloning gh-pages"
 rm -rf gh-pages
@@ -14,13 +17,12 @@ pushd gh-pages > /dev/null 2>&1
 # Replace /draft with this build.
 echo "Publishing to: /draft"
 rm -rf draft
-cp -r ../out draft
+cp -r ../out/ draft
 
 # If this is a tagged commit, publish to a permalink and index.
-GITTAG=$(git tag --points-at HEAD)
 if [ -n "$GITTAG" ]; then
   echo "Publishing to: /$GITTAG"
-  cp -r ../out "$GITTAG"
+  cp -r ../out/ "$GITTAG"
 
   echo "Linking from: / (index)"
   echo '<html>

--- a/spec/GraphQL.md
+++ b/spec/GraphQL.md
@@ -11,6 +11,9 @@ for client-server applications. The development of this standard started
 in 2015. GraphQL is a new and evolving language and is not complete. Significant
 enhancement will continue in future editions of this specification.
 
+Previous releases of the GraphQL specification can be found at permalinks that
+match their [release tag](https://github.com/facebook/graphql/releases).
+
 **Copyright notice**
 
 Copyright (c) 2015-2017, Facebook, Inc. All rights reserved.
@@ -43,7 +46,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 **Conformance**
 
-A conforming implementation of GraphQL must fulfill all normative requirements. 
+A conforming implementation of GraphQL must fulfill all normative requirements.
 Conformance requirements are described in this document via both
 descriptive assertions and key words with clearly defined meanings.
 


### PR DESCRIPTION
This adds a script which amends to the gh-pages repo rather than replacing it, keeping a latest copy at /draft, and redirecting index to the latest released copy of the spec.