### PR TITLE
Change order of fields inside Response

### DIFF
--- a/spec/Section 7 -- Response.md
+++ b/spec/Section 7 -- Response.md
@@ -85,15 +85,15 @@ objects in the response as unordered Maps and arrive at a valid value.
 
 A response to a GraphQL operation must be a map.
 
-If the operation included execution, the response map must contain a first entry
-with key `data`. The value of this entry is described in the "Data" section. If
-the operation failed before execution, due to a syntax error, missing
-information, or validation error, this entry must not be present.
-
-If the operation encountered any errors, the response map must contain a next
+If the operation encountered any errors, the response map must contain a first
 entry with key `errors`. The value of this entry is described in the "Errors"
 section. If the operation completed without encountering any errors, this entry
 must not be present.
+
+If the operation included execution, the response map must contain a next entry
+with key `data`. The value of this entry is described in the "Data" section. If
+the operation failed before execution, due to a syntax error, missing
+information, or validation error, this entry must not be present.
 
 The response map may also contain an entry with key `extensions`. This entry,
 if set, must have a map as its value. This entry is reserved for implementors

--- a/spec/Section 7 -- Response.md
+++ b/spec/Section 7 -- Response.md
@@ -85,12 +85,12 @@ objects in the response as unordered Maps and arrive at a valid value.
 
 A response to a GraphQL operation must be a map.
 
-If the operation encountered any errors, the response map must contain a first
+If the operation encountered any errors, the response map must contain an
 entry with key `errors`. The value of this entry is described in the "Errors"
 section. If the operation completed without encountering any errors, this entry
 must not be present.
 
-If the operation included execution, the response map must contain a next entry
+If the operation included execution, the response map must contain an entry
 with key `data`. The value of this entry is described in the "Data" section. If
 the operation failed before execution, due to a syntax error, missing
 information, or validation error, this entry must not be present.
@@ -104,6 +104,9 @@ To ensure future changes to the protocol do not break existing servers and
 clients, the top level response map must not contain any entries other than the
 three described above.
 
+Note: When `errors` is present in the response, it may be helpful for it to 
+appear first when serialized to make it more clear when errors are present
+in a response during debugging.
 
 ### Data
 


### PR DESCRIPTION
Currently, the spec requires `data` to be the first field in a response.
But after [my PR](https://github.com/graphql/graphql-js/pull/838) was merged into `graphql-js`, `errors` always precede `data`:
![image](https://user-images.githubusercontent.com/8336157/33083372-e26a2dea-cee7-11e7-9361-a1b4a2686665.png)

I still think that having `errors` as the first property is a big DX improvement so I updated the spec to reflect the change in `graphql-js`.