### PR TITLE
Add Code of Conduct

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,3 @@
+# Code of Conduct
+
+Facebook has adopted a Code of Conduct that we expect project participants to adhere to. Please [read the full text](https://code.facebook.com/codeofconduct) so that you can understand what actions will and will not be tolerated.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,6 +16,9 @@ or client implementations** should go through the stages below no matter how
 small they are. All other changes should be labeled as “editorial” and may
 be merged right away.
 
+## Code of Conduct
+The code of conduct is described in [`CODE_OF_CONDUCT.md`](CODE_OF_CONDUCT.md)
+
 ## Stage -2: proposed change (optional)
 
 **Prerequisite**: Described problem/change should be specific to the content of

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,10 +14,7 @@ status and progress of proposals.
 Any changes to the specification that affect the behavior of **GraphQL server
 or client implementations** should go through the stages below no matter how
 small they are. All other changes should be labeled as “editorial” and may
-be merged right away.
-
-## Code of Conduct
-The code of conduct is described in [`CODE_OF_CONDUCT.md`](CODE_OF_CONDUCT.md)
+be merged right away.  Also, please read the [Code of Conduct](CODE_OF_CONDUCT.md)
 
 ## Stage -2: proposed change (optional)
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,6 +15,7 @@ Any changes to the specification that affect the behavior of **GraphQL server
 or client implementations** should go through the stages below no matter how
 small they are. All other changes should be labeled as “editorial” and may
 be merged right away.  Also, please read the [Code of Conduct](CODE_OF_CONDUCT.md)
+to know what is expected when making contributions to this project.
 
 ## Stage -2: proposed change (optional)
 


### PR DESCRIPTION
In the past there was not info and support to add these docs to all Facebook Open Source projects. We can fix it. :)

**NOTE:** This is an "editorial" change, or rather it does not make any changes to the GraphQL spec itself.

**why make this change?:**
Facebook Open Source provides a Code of Conduct statement for all
projects to follow, to promote a welcoming and safe open source community.

Exposing the COC via a separate markdown file is a standard being
promoted by Github via the Community Profile in order to meet their Open
Source Guide's recommended community standards.

As you can see, adding this file will improve [the GraphQL community profile](https://github.com/facebook/graphql/community)
checklist and increase the visibility of our COC.

**test plan:**
Viewing it on my branch -
<img width="1497" alt="screen shot 2018-01-14 at 2 43 03 pm" src="https://user-images.githubusercontent.com/1114467/34921585-6aee60ac-f939-11e7-8d72-b1d1dcc949fb.png">
<img width="1513" alt="screen shot 2018-01-14 at 2 43 13 pm" src="https://user-images.githubusercontent.com/1114467/34921586-6b077d58-f939-11e7-9491-6b76b355b935.png">


**issue:**
internal task t23481323