### PR TITLE
Remove number of excessive whitespaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -279,7 +279,7 @@ this query would then be:
 ```
 
 Specifying the `query` keyword and an operation name is only required when a
-GraphQL document defines multiple operations.  We therefore could have written
+GraphQL document defines multiple operations. We therefore could have written
 the previous query with the query shorthand:
 
 ```graphql
@@ -362,7 +362,7 @@ which will give us the nested response
     "friends": [
       {
         "name": "Luke Skywalker",
-        "appearsIn": [ "NEWHOPE", "EMPIRE", "JEDI" ],
+        "appearsIn": ["NEWHOPE", "EMPIRE", "JEDI"],
         "friends": [
           { "name": "Han Solo" },
           { "name": "Leia Organa" },
@@ -372,7 +372,7 @@ which will give us the nested response
       },
       {
         "name": "Han Solo",
-        "appearsIn": [ "NEWHOPE", "EMPIRE", "JEDI" ],
+        "appearsIn": ["NEWHOPE", "EMPIRE", "JEDI"],
         "friends": [
           { "name": "Luke Skywalker" },
           { "name": "Leia Organa" },
@@ -381,7 +381,7 @@ which will give us the nested response
       },
       {
         "name": "Leia Organa",
-        "appearsIn": [ "NEWHOPE", "EMPIRE", "JEDI" ],
+        "appearsIn": ["NEWHOPE", "EMPIRE", "JEDI"],
         "friends": [
           { "name": "Luke Skywalker" },
           { "name": "Han Solo" },

--- a/rfcs/Subscriptions.md
+++ b/rfcs/Subscriptions.md
@@ -69,7 +69,7 @@ We'll try to define the irreducible components of a GraphQL Subscriptions system
 
 The lifetime of a subscription looks like this:
 
-* **Subscribe:** the Client initializes a subscription by sending a query and its variables to the server.  When the Subscription is created, the input query and variables are mapped to a stream of events to which the Subscription listens. The server _may_ send an initial publish from executing the subscription operation.
+* **Subscribe:** the Client initializes a subscription by sending a query and its variables to the server. When the Subscription is created, the input query and variables are mapped to a stream of events to which the Subscription listens. The server _may_ send an initial publish from executing the subscription operation.
 
 * **Publish:** when any of the events associated with the subscription are triggered, the subscription executes the query, variables, and payload and sends the result to the client.
 

--- a/spec/GraphQL.md
+++ b/spec/GraphQL.md
@@ -49,7 +49,7 @@ Conformance requirements are described in this document via both
 descriptive assertions and key words with clearly defined meanings.
 
 The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD",
-"SHOULD NOT", "RECOMMENDED",  "MAY", and "OPTIONAL" in the normative portions of
+"SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in the normative portions of
 this document are to be interpreted as described in [IETF RFC 2119](https://tools.ietf.org/html/rfc2119).
 These key words may appear in lowercase and still retain their meaning unless
 explicitly declared as non-normative.

--- a/spec/Section 2 -- Language.md
+++ b/spec/Section 2 -- Language.md
@@ -488,7 +488,7 @@ fragment friendFields on User {
 }
 ```
 
-Fragments are consumed by using the spread operator (`...`).  All fields selected
+Fragments are consumed by using the spread operator (`...`). All fields selected
 by the fragment will be added to the query field selection at the same level
 as the fragment invocation. This happens through multiple levels of fragment
 spreads.
@@ -925,7 +925,7 @@ ObjectValue[Const] :
 ObjectField[Const] : Name : Value[?Const]
 
 Input object literal values are unordered lists of keyed input values wrapped in
-curly-braces `{ }`.  The values of an object literal may be any input value
+curly-braces `{ }`. The values of an object literal may be any input value
 literal or variable (ex. `{ name: "Hello world", score: 1.0 }`). We refer to
 literal representation of input objects as "object literals."
 

--- a/spec/Section 3 -- Type System.md
+++ b/spec/Section 3 -- Type System.md
@@ -791,7 +791,7 @@ they sometimes need to be more complex than this.
 The `Object` type defined above is inappropriate for re-use here, because
 `Object`s can contain fields that express circular references or references
 to interfaces and unions, neither of which is appropriate for use as an
-input argument.  For this reason, input objects have a separate type in the
+input argument. For this reason, input objects have a separate type in the
 system.
 
 An `Input Object` defines a set of input fields; the input fields are either

--- a/spec/Section 5 -- Validation.md
+++ b/spec/Section 5 -- Validation.md
@@ -934,7 +934,7 @@ referenced.
 **Explanatory Text**
 
 Named fragment spreads must refer to fragments defined
-within the document.  If the target of a spread is
+within the document. If the target of a spread is
 not defined, this is an error:
 
 ```graphql counter-example

--- a/spec/Section 7 -- Response.md
+++ b/spec/Section 7 -- Response.md
@@ -104,7 +104,7 @@ To ensure future changes to the protocol do not break existing servers and
 clients, the top level response map must not contain any entries other than the
 three described above.
 
-Note: When `errors` is present in the response, it may be helpful for it to 
+Note: When `errors` is present in the response, it may be helpful for it to
 appear first when serialized to make it more clear when errors are present
 in a response during debugging.
 


### PR DESCRIPTION
I was wondering if it's possible to use `prettier` on markdown files in this repo and [found a few bugs in prettier](https://github.com/prettier/prettier/issues?q=is%3Aissue+is%3Aopen+sort%3Aupdated-desc+author%3AIvanGoncharov) that makes it impossible to use.
But reviewing the diff I found multiple places with excessive whitespaces.