### PR TITLE
Fix Markdown links

### DIFF
--- a/spec/GraphQL.md
+++ b/spec/GraphQL.md
@@ -102,20 +102,20 @@ explicitly in prose (e.g. "Note: ") or are set apart in a note block, like this:
 Note: This is an example of a non-normative note.
 
 
-# [Overview](Section 1 -- Overview.md)
+# [Overview](Section%201%20--%20Overview.md)
 
-# [Language](Section 2 -- Language.md)
+# [Language](Section%202%20--%20Language.md)
 
-# [Type System](Section 3 -- Type System.md)
+# [Type System](Section%203%20--%20Type%20System.md)
 
-# [Introspection](Section 4 -- Introspection.md)
+# [Introspection](Section%204%20--%20Introspection.md)
 
-# [Validation](Section 5 -- Validation.md)
+# [Validation](Section%205%20--%20Validation.md)
 
-# [Execution](Section 6 -- Execution.md)
+# [Execution](Section%206%20--%20Execution.md)
 
-# [Response](Section 7 -- Response.md)
+# [Response](Section%207%20--%20Response.md)
 
-# [Appendix: Notation Conventions](Appendix A -- Notation Conventions.md)
+# [Appendix: Notation Conventions](Appendix%20A%20--%20Notation%20Conventions.md)
 
-# [Appendix: Grammar Summary](Appendix B -- Grammar Summary.md)
+# [Appendix: Grammar Summary](Appendix%20B%20--%20Grammar%20Summary.md)


### PR DESCRIPTION
This PR fixes the links navigation at Github.

Before | After
---|---
![image](https://user-images.githubusercontent.com/284515/36026912-30adceb8-0d80-11e8-8077-a35d93489366.png) | ![image](https://user-images.githubusercontent.com/284515/36026946-5c7e73bc-0d80-11e8-888f-a3c0ad7fd1fe.png)


