### PR TITLE
Add optional 'extensions' entry to errors

### DIFF
--- a/spec/Section 7 -- Response.md
+++ b/spec/Section 7 -- Response.md
@@ -248,6 +248,42 @@ be the same:
 }
 ```
 
-GraphQL servers may provide additional entries to error as they choose to
-produce more helpful or machine-readable errors, however future versions of the
-spec may describe additional entries to errors.
+GraphQL servers may provide an additional entry with key `extensions`. This
+entry, if set, must have a map as its value. This entry is reserved for
+implementors to extend errors however they see fit, and hence there are no
+additional restrictions on its contents.
+
+To provide compatibility with the previous versions of this spec, it is allowed
+to add additional entries to error itself. However such non-standard entries are
+highly discouraged since they may conflict with additional entries that can be
+added in the future versions of the spec.
+
+```json example
+{
+  "errors": [
+    {
+      "message": "Name for character with ID 1002 could not be fetched.",
+      "locations": [ { "line": 6, "column": 7 } ],
+      "path": [ "hero", "heroFriends", 1, "name" ],
+      "extensions": {
+        "code": "CAN_NOT_FETCH_BY_ID",
+        "timestamp": "Fri Feb 9 14:33:09 UTC 2018"
+      }
+    }
+  ]
+}
+```
+
+```json counter-example
+{
+  "errors": [
+    {
+      "message": "Name for character with ID 1002 could not be fetched.",
+      "locations": [ { "line": 6, "column": 7 } ],
+      "path": [ "hero", "heroFriends", 1, "name" ]
+      "code": "CAN_NOT_FETCH_BY_ID",
+      "timestamp": "Fri Feb 9 14:33:09 UTC 2018"
+    }
+  ]
+}
+```

--- a/spec/Section 7 -- Response.md
+++ b/spec/Section 7 -- Response.md
@@ -270,7 +270,7 @@ there are no additional restrictions on its contents.
 ```
 
 GraphQL services should not provide any additional entries to the error format, 
-since they may conflict with additional entries that may be added in future 
+since they could conflict with additional entries that may be added in future 
 versions of this specification.
 
 > Note: Previous versions of this spec did not describe the `extensions` entry 

--- a/spec/Section 7 -- Response.md
+++ b/spec/Section 7 -- Response.md
@@ -248,15 +248,10 @@ be the same:
 }
 ```
 
-GraphQL servers may provide an additional entry with key `extensions`. This
+GraphQL services may provide an additional entry with key `extensions`. This
 entry, if set, must have a map as its value. This entry is reserved for
-implementors to extend errors however they see fit, and hence there are no
-additional restrictions on its contents.
-
-To provide compatibility with the previous versions of this spec, it is allowed
-to add additional entries to error itself. However such non-standard entries are
-highly discouraged since they may conflict with additional entries that can be
-added in the future versions of the spec.
+implementors to add additional information to errors however they see fit, and 
+there are no additional restrictions on its contents.
 
 ```json example
 {
@@ -273,6 +268,14 @@ added in the future versions of the spec.
   ]
 }
 ```
+
+GraphQL services should not provide any additional entries to the error format, 
+since they may conflict with additional entries that may be added in future 
+versions of this specification.
+
+> Note: Previous versions of this spec did not describe the `extensions` entry 
+> for error formatting. While non-specified entries are not violations, they are
+> still discouraged.
 
 ```json counter-example
 {

--- a/spec/Section 7 -- Response.md
+++ b/spec/Section 7 -- Response.md
@@ -248,9 +248,9 @@ be the same:
 }
 ```
 
-GraphQL services may provide an additional entry to errors with key `extensions`. 
+GraphQL services may provide an additional entry to errors with key `extensions`.
 This entry, if set, must have a map as its value. This entry is reserved for
-implementors to add additional information to errors however they see fit, and 
+implementors to add additional information to errors however they see fit, and
 there are no additional restrictions on its contents.
 
 ```json example
@@ -269,11 +269,11 @@ there are no additional restrictions on its contents.
 }
 ```
 
-GraphQL services should not provide any additional entries to the error format, 
-since they could conflict with additional entries that may be added in future 
+GraphQL services should not provide any additional entries to the error format
+since they could conflict with additional entries that may be added in future
 versions of this specification.
 
-> Note: Previous versions of this spec did not describe the `extensions` entry 
+> Note: Previous versions of this spec did not describe the `extensions` entry
 > for error formatting. While non-specified entries are not violations, they are
 > still discouraged.
 

--- a/spec/Section 7 -- Response.md
+++ b/spec/Section 7 -- Response.md
@@ -248,8 +248,8 @@ be the same:
 }
 ```
 
-GraphQL services may provide an additional entry with key `extensions`. This
-entry, if set, must have a map as its value. This entry is reserved for
+GraphQL services may provide an additional entry to errors with key `extensions`. 
+This entry, if set, must have a map as its value. This entry is reserved for
 implementors to add additional information to errors however they see fit, and 
 there are no additional restrictions on its contents.
 


### PR DESCRIPTION
As discussed on the last WG meetup it makes sense to define some common error properties like: `code`, `category`, etc. I think such initiative should be lead by public API owners and required broader discussion. 

However, I think we could make this process more painless by proactively preventing possible name clashes.
For example, if a future version of spec will defines `code` as a string it can break some public API that use integers for error codes.

Another alternative would be to recommend prefixing additional fields with `x-` (e.g. `x-code`) but I think it's better to reuse `extensions` from response object.