### PR TITLE
Bump to latest version of spec-md + npm run watch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ git:
   depth: 5
 
 language: node_js
-node_js: 6
+node_js: 9
 
 deploy:
   provider: script

--- a/package.json
+++ b/package.json
@@ -17,9 +17,11 @@
   },
   "scripts": {
     "test": "spec-md spec/GraphQL.md > /dev/null",
-    "build": "mkdir -p out; spec-md spec/GraphQL.md > out/index.html"
+    "build": "mkdir -p out; spec-md spec/GraphQL.md > out/index.html",
+    "watch": "mkdir -p out; nodemon --exec 'spec-md > out/index.html' spec/GraphQL.md"
   },
   "devDependencies": {
-    "spec-md": "0.5.1"
+    "nodemon": "1.17.1",
+    "spec-md": "0.6.0"
   }
 }


### PR DESCRIPTION
The most recent version of spec-md fixes a few bugs and adds keyword highlighting which makes reading algorithms a bit more pleasent.

This also introduces nodemon and an `npm run watch` script which rebuilds output when markdown files change.