### PR TITLE
RFC: Fix ambiguity with null variable values and default values

### DIFF
--- a/spec/Section 3 -- Type System.md
+++ b/spec/Section 3 -- Type System.md
@@ -1262,25 +1262,36 @@ type of an Object or Interface field.
 **Input Coercion**
 
 The value for an input object should be an input object literal or an unordered
-map supplied by a variable, otherwise an error should be thrown. In either
-case, the input object literal or unordered map should not contain any entries
+map supplied by a variable, otherwise an error must be thrown. In either
+case, the input object literal or unordered map must not contain any entries
 with names not defined by a field of this input object type, otherwise an error
-should be thrown.
+must be thrown.
 
 The result of coercion is an unordered map with an entry for each field both
-defined by the input object type and provided with a value. If the value {null}
-was provided, an entry in the coerced unordered map must exist for that field.
-In other words, there is a semantic difference between the explicitly provided
-value {null} versus having not provided a value.
+defined by the input object type and for which a value exists. The resulting map
+is constructed with the following rules:
 
-The value of each entry in the coerced unordered map is the result of input
-coercion of the value provided for that field for the type of the field defined
-by the input object type
+* If no value is provided for a defined input object field and that field
+  definition provides a default value, the default value should be used. If no
+  default value is provided and the input object field's type is non-null, an
+  error should be thrown. Otherwise, if the field is not required, then no entry
+  is added to the coerced unordered map.
 
-Any non-nullable field defined by the input object type which does not have
-a corresponding entry in the original value, or is represented by a variable
-which was not provided a value, or for which the value {null} was provided, an
-error should be thrown.
+* If the value {null} was provided for an input object field, and the field's
+  type is not a non-null type, an entry in the coerced unordered map is given
+  the value {null}. In other words, there is a semantic difference between the
+  explicitly provided value {null} versus having not provided a value.
+
+* If a literal value is provided for an input object field, an entry in the
+  coerced unordered map is given the result of coercing that value according
+  to the input coercion rules for the type of that field.
+
+* If a variable is provided for an input object field, the runtime value of that
+  variable must be used. If the runtime value is {null} and the field type
+  is non-null, a field error must be thrown. If no runtime value is provided,
+  the variable definition's default value should be used. If the variable
+  definition does not provide a default value, the input object field
+  definition's default value should be used.
 
 Following are examples of input coercion for an input object type with a
 `String` field `a` and a required (non-null) `Int!` field `b`:

--- a/spec/Section 5 -- Validation.md
+++ b/spec/Section 5 -- Validation.md
@@ -1825,11 +1825,12 @@ an extraneous variable.
   * For each {operation} in {document}:
   * Let {variableUsages} be all usages transitively included in the {operation}.
   * For each {variableUsage} in {variableUsages}:
-    * {IsVariableUsageAllowed(variableUsage)} must be {true}.
+    * Let {variableName} be the name of {variableUsage}.
+    * Let {variableDefinition} be the {VariableDefinition} named {variableName}
+      defined within {operation}.
+    * {IsVariableUsageAllowed(variableDefinition, variableUsage)} must be {true}.
 
-IsVariableUsageAllowed(variableUsage):
-  * Let {variableName} be the name of {variableUsage}.
-  * Let {variableDefinition} be the {VariableDefinition} in {operation}.
+IsVariableUsageAllowed(variableDefinition, variableUsage):
   * Let {variableType} be the expected type of {variableDefinition}.
   * Let {locationType} be the expected type of the {Argument}, {ObjectField},
     or {ListValue} entry where {variableUsage} is located.

--- a/spec/Section 5 -- Validation.md
+++ b/spec/Section 5 -- Validation.md
@@ -739,7 +739,7 @@ fragment goodBooleanArg on Arguments {
 }
 
 fragment goodNonNullArg on Arguments {
-  requiredBooleanArgField(requiredBooleanArg: true)
+  nonNullBooleanArgField(nonNullBooleanArg: true)
 }
 ```
 
@@ -757,7 +757,7 @@ but this is not valid on a required argument.
 
 ```graphql counter-example
 fragment missingRequiredArg on Arguments {
-  requiredBooleanArgField
+  nonNullBooleanArgField
 }
 ```
 
@@ -766,7 +766,7 @@ always have a non-null type.
 
 ```graphql counter-example
 fragment missingRequiredArg on Arguments {
-  requiredBooleanArgField(requiredBooleanArg: null)
+  nonNullBooleanArgField(nonNullBooleanArg: null)
 }
 ```
 

--- a/spec/Section 5 -- Validation.md
+++ b/spec/Section 5 -- Validation.md
@@ -1832,21 +1832,19 @@ an extraneous variable.
 
 AreTypesCompatible(argumentType, variableType):
   * If {argumentType} is a non-null type:
-    * If {variableType} is a non-null type:
-      * Let {nullableArgumentType} be the nullable type of {argumentType}.
-      * Let {nullableVariableType} be the nullable type of {variableType}.
-      * Return {AreTypesCompatible(nullableArgumentType, nullableVariableType)}.
-    * Otherwise, return {false}.
-  * If {variableType} is a non-null type:
+    * If {variableType} is NOT a non-null type, return {false}.
+    * Let {nullableArgumentType} be the nullable type of {argumentType}.
+    * Let {nullableVariableType} be the nullable type of {variableType}.
+    * Return {AreTypesCompatible(nullableArgumentType, nullableVariableType)}.
+  * Otherwise, if {variableType} is a non-null type:
     * Let {nullableVariableType} be the nullable type of {variableType}.
     * Return {AreTypesCompatible(argumentType, nullableVariableType)}.
-  * If {argumentType} is a list type:
-    * If {variableType} is a list type:
-      * Let {itemArgumentType} be the item type of {argumentType}.
-      * Let {itemVariableType} be the item type of {variableType}.
-      * Return {AreTypesCompatible(itemArgumentType, itemVariableType)}.
-    * Otherwise, return {false}.
-  * If {variableType} is a list type, return {false}.
+  * Otherwise, if {argumentType} is a list type:
+    * If {variableType} is NOT a list type, return {false}.
+    * Let {itemArgumentType} be the item type of {argumentType}.
+    * Let {itemVariableType} be the item type of {variableType}.
+    * Return {AreTypesCompatible(itemArgumentType, itemVariableType)}.
+  * Otherwise, if {variableType} is a list type, return {false}.
   * Return {true} if {variableType} and {argumentType} are identical, otherwise {false}.
 
 **Explanatory Text**

--- a/spec/Section 6 -- Execution.md
+++ b/spec/Section 6 -- Execution.md
@@ -88,21 +88,22 @@ CoerceVariableValues(schema, operation, variableValues):
       name {variableName}.
     * Let {value} be the value provided in {variableValues} for the
       name {variableName}.
-    * If {hasValue} is not {true} or if {value} is {null}:
-      * If {variableType} is a Non-Nullable type, throw a query error.
-      * Otherwise if {defaultValue} exists (including {null}):
-        * Add an entry to {coercedValues} named {variableName} with the
-          value {defaultValue}.
-      * Otherwise if {hasValue} is {true} and {value} is {null}:
+    * If {hasValue} is not {true} and {defaultValue} exists (including {null}):
+      * Add an entry to {coercedValues} named {variableName} with the
+        value {defaultValue}.
+    * Otherwise if {variableType} is a Non-Nullable type, and either {hasValue}
+      is not {true} or {value} is {null}, throw a query error.
+    * Otherwise if {hasValue} is true:
+      * If {value} is {null}:
         * Add an entry to {coercedValues} named {variableName} with the
           value {null}.
-    * Otherwise, {value} must not be {null}:
-      * If {value} cannot be coerced according to the input coercion
-        rules of {variableType}, throw a query error.
-      * Let {coercedValue} be the result of coercing {value} according to the
-        input coercion rules of {variableType}.
-      * Add an entry to {coercedValues} named {variableName} with the
-        value {coercedValue}.
+      * Otherwise:
+        * If {value} cannot be coerced according to the input coercion
+          rules of {variableType}, throw a query error.
+        * Let {coercedValue} be the result of coercing {value} according to the
+          input coercion rules of {variableType}.
+        * Add an entry to {coercedValues} named {variableName} with the
+          value {coercedValue}.
   * Return {coercedValues}.
 
 Note: This algorithm is very similar to {CoerceArgumentValues()}.
@@ -552,34 +553,35 @@ CoerceArgumentValues(objectType, field, variableValues):
     * Let {defaultValue} be the default value for {argumentDefinition}.
     * Let {hasValue} be {true} if {argumentValues} provides a value for the
       name {argumentName}.
-    * Let {value} be the value provided in {argumentValues} for the
+    * Let {argumentValue} be the value provided in {argumentValues} for the
       name {argumentName}.
-    * If {hasValue} is not {true} or if {value} is {null}:
-      * If {argumentType} is a Non-Nullable type, throw a field error.
-      * Otherwise, if {defaultValue} exists (including {null}):
-        * Add an entry to {coercedValues} named {argumentName} with the
-          value {defaultValue}.
-      * Otherwise, if {hasValue} is {true} and {value} is {null}:
+    * If {argumentValue} is a {Variable}:
+      * Let {variableName} be the name of {argumentValue}.
+      * Let {hasValue} be {true} if {variableValues} provides a value for the
+        name {variableName}.
+      * Let {value} be the value provided in {variableValues} for the
+        name {variableName}.
+    * Otherwise:
+      * Let {value} be {argumentValue}.
+    * If {hasValue} is not {true} and {defaultValue} exists (including {null}):
+      * Add an entry to {coercedValues} named {argumentName} with the
+        value {defaultValue}.
+    * Otherwise if {argumentType} is a Non-Nullable type, and either {hasValue}
+      is not {true} or {value} is {null}, throw a field error.
+    * Otherwise if {hasValue} is true:
+      * If {value} is {null}:
         * Add an entry to {coercedValues} named {argumentName} with the
           value {null}.
-    * Otherwise, if {value} is a {Variable}:
-      * Let {variableName} be the name of {value}.
-      * If {variableValues} provides a value for the name {variableName}:
-        * Let {variableValue} be the value provided in {variableValues} for the
-          name {variableName}.
+      * Otherwise, if {argumentValue} is a {Variable}:
         * Add an entry to {coercedValues} named {argumentName} with the
-          value {variableValue}.
-      * Otherwise, if {argumentType} is a Non-Nullable type, throw a field error.
-      * Otherwise, if {defaultValue} exists (including {null}):
+          value {value}.
+      * Otherwise:
+        * If {value} cannot be coerced according to the input coercion
+            rules of {variableType}, throw a field error.
+        * Let {coercedValue} be the result of coercing {value} according to the
+          input coercion rules of {variableType}.
         * Add an entry to {coercedValues} named {argumentName} with the
-          value {defaultValue}.
-    * Otherwise, {value} must be a {Value} and not {null}:
-      * If {value} cannot be coerced according to the input coercion
-        rules of {argType}, throw a field error.
-      * Let {coercedValue} be the result of coercing {value} according to the
-        input coercion rules of {argType}.
-      * Add an entry to {coercedValues} named {argumentName} with the
-        value {coercedValue}.
+          value {coercedValue}.
   * Return {coercedValues}.
 
 Note: Variable values are not coerced because they are expected to be coerced

--- a/spec/Section 6 -- Execution.md
+++ b/spec/Section 6 -- Execution.md
@@ -561,8 +561,7 @@ CoerceArgumentValues(objectType, field, variableValues):
         name {variableName}.
       * Let {value} be the value provided in {variableValues} for the
         name {variableName}.
-    * Otherwise:
-      * Let {value} be {argumentValue}.
+    * Otherwise, let {value} be {argumentValue}.
     * If {hasValue} is not {true} and {defaultValue} exists (including {null}):
       * Add an entry to {coercedValues} named {argumentName} with the
         value {defaultValue}.

--- a/spec/Section 6 -- Execution.md
+++ b/spec/Section 6 -- Execution.md
@@ -538,8 +538,8 @@ order to correctly produce a value. These arguments are defined by the field in
 the type system to have a specific input type: Scalars, Enum, Input Object, or
 List or Non-Null wrapped variations of these three.
 
-At each argument position in a query may be a literal {Value} or {Variable} to
-be provided at runtime.
+At each argument position in a query may be a literal {Value}, or a {Variable}
+to be provided at runtime.
 
 CoerceArgumentValues(objectType, field, variableValues):
   * Let {coercedValues} be an empty unordered Map.


### PR DESCRIPTION
(Rendering Preview: https://out-nmocjoypvp.now.sh)

This is a *NON-BREAKING* **validation change** which allows some previously invalid queries. It is also a behavioral **execution change** which changes how values interact with variable and argument default values.

There is currently ambiguity and inconsistency in how `null` values are coerced and resolved as part of variable values, default values, and argument values. This inconsistency and ambiguity can allow for `null` values to appear at non-null arguments, which might result in unforseen null-pointer-errors.

The version of this proposal to be merged includes the following:

* *NEW*: Non-null arguments and input object fields are no longer required to be provided a value/variable if that argument also supplies a default value.
* *NEW*: Similarly, non-null input object fields can be omitted if they supply a default value. (Note that previously this validation clause was missing from the spec, however has long been included in reference implementations)
* *NEW*: All variables can now have default values by way of removing a validation rule. Previously it was invalid to supply a default value with a non-null variable.
* *BUG FIX*: Variables with a nullable type and a `null` default value cannot be provided to a non-null argument or input field.
* *NEW*: Optional (nullable) variables can now be used for arguments or input object fields which supply default values.
* *CLARITY*: Redefine `CoerceVariableValues()` to make it more clear how to treat a lack of runtime value vs the explicit value `null` with respect to default values and type coercion.
* *NEW*: Redefine `CoerceArgumentValues()` to ensure providing a `null` variable value to a Non-Null argument type causes a field error, and to add clarity to how `null` values and default values should be treated.
* *NEW*: Redefine Input object coercion rules to ensure providing a `null` value or runtime variable value to a non-null type causes a field error, and improve clarity for these coercion rules. This mirrors the changes to `CoerceArgumentValues()`.

---

Previous version of this proposal:

<strike>

This appears in three distinct but related issues:

**Validation: All Variable Usages are Allowed**

The explicit value `null` may be used as a default value for a variable with a nullable type, however this rule asks to treat a variable's type as non-null if it has a default value. Instead this rule should specifically only treat the variable's type as non-null if the default value is not `null`.

Additionally, the `AreTypesCompatible` algorithm is underspecificied, which could lead to further misinterpretation of this validation rule.

**Coercing Variable Values**

`CoerceVariableValues()` allows the explicit `null` value to be used instead of a default value. This can result in a null value flowing to a non-null argument due to the validation rule mentioned above. Instead a default value must be used even when an explicit `null` value is provided. This is also more consistent with the explanation for validation rule "Variable Default Value Is Allowed"

Also, how to treat an explicit `null` value is currently underspecified. While an input object explains that a `null` value should result in an explicit `null` value at the input object field, there is no similar explaination for typical scalar input types. Instead, `CoerceVariableValues()` should explicitly handle the `null` value to make it clear a `null` is the resulting value in the `coercedValues` Map.

**Coercing Argument Values**

The `CoerceArgumentValues()` algorithm is intentionally similar to `CoerceVariableValues()` and suffers from the same inconsistency. Explicit `null` values should not take precedence over default values, and should also be explicitly handled rather than left to underspecified input scalar coercion.