### PR TITLE
RFC: SchemaExtension

### DIFF
--- a/spec/Appendix B -- Grammar Summary.md
+++ b/spec/Appendix B -- Grammar Summary.md
@@ -187,10 +187,18 @@ Directive[Const] : @ Name Arguments[?Const]?
 TypeSystemDefinition :
   - SchemaDefinition
   - TypeDefinition
-  - TypeExtension
   - DirectiveDefinition
+  - TypeSystemExtension
+
+TypeSystemExtension :
+  - SchemaExtension
+  - TypeExtension
 
 SchemaDefinition : schema Directives[Const]? { OperationTypeDefinition+ }
+
+SchemaExtension :
+  - extend schema Directives[Const]? { OperationTypeDefinition+ }
+  - extend schema Directives[Const]
 
 OperationTypeDefinition : OperationType : NamedType
 

--- a/spec/Appendix B -- Grammar Summary.md
+++ b/spec/Appendix B -- Grammar Summary.md
@@ -96,6 +96,7 @@ Document : Definition+
 Definition :
   - ExecutableDefinition
   - TypeSystemDefinition
+  - TypeSystemExtension
 
 ExecutableDefinition :
   - OperationDefinition
@@ -188,7 +189,6 @@ TypeSystemDefinition :
   - SchemaDefinition
   - TypeDefinition
   - DirectiveDefinition
-  - TypeSystemExtension
 
 TypeSystemExtension :
   - SchemaExtension

--- a/spec/Section 2 -- Language.md
+++ b/spec/Section 2 -- Language.md
@@ -171,6 +171,7 @@ Document : Definition+
 Definition :
   - ExecutableDefinition
   - TypeSystemDefinition
+  - TypeSystemExtension
 
 ExecutableDefinition :
   - OperationDefinition
@@ -181,9 +182,9 @@ by a GraphQL service or client. A document contains multiple definitions, either
 executable or representative of a GraphQL type system.
 
 Documents are only executable by a GraphQL service if they contain an
-{OperationDefinition}, only contain {ExecutableDefinition} and do not contain
-{TypeSystemDefinition}. However documents which do not contain
-{OperationDefinition} or do contain {TypeSystemDefinition} may still be parsed
+{OperationDefinition} and otherwise only contain {ExecutableDefinition}.
+However documents which do not contain {OperationDefinition} or do contain
+{TypeSystemDefinition} or {TypeSystemExtension} may still be parsed
 and validated to allow client tools to represent many GraphQL uses which may
 appear across many individual files.
 
@@ -195,8 +196,8 @@ multiple operations to a GraphQL service, the name of the desired operation to
 be executed must also be provided.
 
 GraphQL services which only seek to provide GraphQL query execution may choose
-to only include {ExecutableDefinition} and omit the {TypeSystemDefinition} rule
-from {Definition}.
+to only include {ExecutableDefinition} and omit the {TypeSystemDefinition} and
+{TypeSystemExtension} rules from {Definition}.
 
 
 ## Operations

--- a/spec/Section 3 -- Type System.md
+++ b/spec/Section 3 -- Type System.md
@@ -8,8 +8,8 @@ are valid.
 TypeSystemDefinition :
   - SchemaDefinition
   - TypeDefinition
-  - TypeExtension
   - DirectiveDefinition
+  - TypeSystemExtension
 
 The GraphQL language includes an
 [IDL](https://en.wikipedia.org/wiki/Interface_description_language) used to
@@ -25,6 +25,18 @@ system definitions should return a descriptive error.
 
 Note: The type system definition language is used throughout the remainder of
 this specification document when illustrating example type systems.
+
+
+## Type System Extensions
+
+TypeSystemExtension :
+  - SchemaExtension
+  - TypeExtension
+
+Type system extensions are used to represent a GraphQL type system which has been
+extended from some original type system. For example, this might be used by a
+local service to represent data a GraphQL client only accesses locally, or by a
+GraphQL service which is itself an extension of another GraphQL service.
 
 
 ## Schema
@@ -138,6 +150,16 @@ type Query {
   someField: String
 }
 ```
+
+### Schema Extension
+
+SchemaExtension :
+  - extend schema Directives[Const]? { OperationTypeDefinition+ }
+  - extend schema Directives[Const]
+
+Schema extensions are used to represent a schema which has been extended from
+an original schema. For example, this might be used by a GraphQL service which
+adds additional operation types, or additional directives to an existing schema.
 
 
 ## Descriptions
@@ -261,10 +283,9 @@ TypeExtension :
   - EnumTypeExtension
   - InputObjectTypeExtension
 
-Type extensions are used to represent a GraphQL type system which has been
-extended from some original type system. For example, this might be used by a
-local service to represent data a GraphQL client only accesses locally, or by a
-GraphQL service which is itself an extension of another GraphQL service.
+Type extensions are used to represent a GraphQL type which has been extended
+from some original type. For example, this might be used by a local service to
+represent additional fields a GraphQL client only accesses locally.
 
 
 ## Scalars

--- a/spec/Section 3 -- Type System.md
+++ b/spec/Section 3 -- Type System.md
@@ -9,7 +9,6 @@ TypeSystemDefinition :
   - SchemaDefinition
   - TypeDefinition
   - DirectiveDefinition
-  - TypeSystemExtension
 
 The GraphQL language includes an
 [IDL](https://en.wikipedia.org/wiki/Interface_description_language) used to


### PR DESCRIPTION
This adds new grammar to the GraphQL SDL:

```graphql
extend schema {
  mutation: MutationType
}
```

This feels like the missing piece of the type system extension framework. In addition to extending types in a type system, the top level schema should be extendable as well.