### PR TITLE
Website: redirect using JS to retain query and fragment

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,9 +1,12 @@
 <html>
   <head>
-    <meta http-equiv="refresh" content="0; url=./October2016" />
+    <meta http-equiv="refresh" content="1; url=./October2016" />
     <title>GraphQL Specification</title>
   </head>
   <body>
     Redirecting to the latest release: <a href="./October2016">October2016</a>
+    <script>
+      location.replace("./October2016" + location.search + location.hash);
+    </script>
   </body>
 </html>


### PR DESCRIPTION
When linking to the website, many places (either due to wanting to stay up-to-date or because they did so before the website moved to have multiple spec versions live) link directly to a position in the spec using the top-level path, rather than a specific version.

For example, they link to:
https://facebook.github.io/graphql/#sec-Enums
rather than:
http://facebook.github.io/graphql/October2016/#sec-Enums

The problem is that the `<meta>`-refresh loses any query string or hash-fragment of the URL. So the above, instead of redirecting to the desired:
http://facebook.github.io/graphql/October2016/#sec-Enums
instead just goes to the top of the page:
http://facebook.github.io/graphql/October2016/

This change adds some JS that performs the redirect, additionally repeating the current URL's query string `?...` and fragment `#...` on the redirect, so that the browser jumps to the correct position on the resulting page.
It also alters the `<meta>`-refresh to wait 1 second, allowing the JS to get in but still offering progressive enhancement for cases where the JS is not executed.

The effect can be seen by comparing:
https://facebook.github.io/graphql/#sec-Enums (before)
with:
https://ind1go.github.io/graphql/#sec-Enums (after)
