### PR TITLE
Use "type system definition language" consistently

### DIFF
--- a/spec/Section 3 -- Type System.md
+++ b/spec/Section 3 -- Type System.md
@@ -136,9 +136,9 @@ system definition language can omit the schema definition when the `query`,
 `mutation`, and `subscription` root types are named `Query`, `Mutation`, and
 `Subscription` respectively.
 
-Likewise, when representing a GraphQL schema using the type system language, a
-schema definition should be omitted if it only uses the default root operation
-type names.
+Likewise, when representing a GraphQL schema using the type system definition
+language, a schema definition should be omitted if it only uses the default root
+operation type names.
 
 This example describes a valid complete GraphQL schema, despite not explicitly
 including a `schema` definition. The `Query` type is presumed to be the `query`


### PR DESCRIPTION
All other places reference it as "type system definition language".