### PR TITLE
Remove Interface is implemented by 1+ Objects validation

### DIFF
--- a/spec/Section 3 -- Type System.md
+++ b/spec/Section 3 -- Type System.md
@@ -1013,7 +1013,6 @@ Interface types have the potential to be invalid if incorrectly defined.
    type; no two fields may share the same name.
 3. Each field of an Interface type must not have a name which begins with the
    characters {"__"} (two underscores).
-4. An Interface type must be implemented by at least one Object type.
 
 
 ### Interface Extensions


### PR DESCRIPTION
This validation requirement was a really nasty breaking change for existing GraphQL type systems. Additionally, it is in my opinion actively harmful to an iterative development model, where you'd define an interface that a field returns, develop on the client against that interface, then days or weeks later, create one or more types that implement the interface, which old clients can start using immediately.