### PR TITLE
RFC: Require Interfaces to have 1+ Objects implementing

### DIFF
--- a/spec/Section 3 -- Type System.md
+++ b/spec/Section 3 -- Type System.md
@@ -1013,6 +1013,7 @@ Interface types have the potential to be invalid if incorrectly defined.
    type; no two fields may share the same name.
 3. Each field of an Interface type must not have a name which begins with the
    characters {"__"} (two underscores).
+4. An Interface type must be implemented by at least one Object type.
 
 
 ### Interface Extensions


### PR DESCRIPTION
Re-applies #424, but as an RFC. This change is a major spec breaking change, and if it is desire-able, we should provide an upgrade path for existing schemas.