### PR TITLE
Add example of negative integer coercion to ID

### DIFF
--- a/spec/Section 3 -- Type System.md
+++ b/spec/Section 3 -- Type System.md
@@ -524,10 +524,11 @@ When coercion is not possible they must raise a field error.
 
 **Input Coercion**
 
-When expected as an input type, any string (such as `"4"`) or integer (such
-as `4`) input value should be coerced to ID as appropriate for the ID formats
-a given GraphQL server expects. Any other input value, including float input
-values (such as `4.0`), must raise a query error indicating an incorrect type.
+When expected as an input type, any string (such as `"4"`) or integer (such as
+`4` or `-4`) input value should be coerced to ID as appropriate for the ID
+formats a given GraphQL server expects. Any other input value, including float
+input values (such as `4.0`), must raise a query error indicating an incorrect
+type.
 
 
 ### Scalar Extensions


### PR DESCRIPTION
Changed from:
> or integer (such as `4`) input value

to
> or non-negative integer (such as `0` or `4`) input value