### PR TITLE
Added missing bracket to list input coercion table.

### DIFF
--- a/spec/Section 3 -- Type System.md
+++ b/spec/Section 3 -- Type System.md
@@ -1489,11 +1489,10 @@ Expected Type | Provided Value   | Coerced Value
 `[Int]`       | `[1, "b", true]` | Error: Incorrect item value
 `[Int]`       | `1`              | `[1]`
 `[Int]`       | `null`           | `null`
-`[[Int]]`     | `[[1], [2, 3]]`  | `[[1], [2, 3]`
+`[[Int]]`     | `[[1], [2, 3]]`  | `[[1], [2, 3]]`
 `[[Int]]`     | `[1, 2, 3]`      | Error: Incorrect item value
 `[[Int]]`     | `1`              | `[[1]]`
 `[[Int]]`     | `null`           | `null`
-
 
 ## Non-Null
 


### PR DESCRIPTION
This is a small one. There is a missing bracket in the list input coercion table.

`[[Int]]`     | `[[1], [2, 3]]`  | `[[1], [2, 3]`

This PR amends this.